### PR TITLE
Fix Unreal interface class naming mismatches

### DIFF
--- a/Source/Vibeheim/WorldGen/Public/Services/HeightfieldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/HeightfieldService.h
@@ -76,14 +76,14 @@ struct VIBEHEIM_API FHeightfieldGenerationSettings
  * Provides deterministic heightfield generation with noise and climate integration
  */
 UCLASS(BlueprintType)
-class VIBEHEIM_API UHeightfieldService : public UObject, public IHeightfieldService
+class VIBEHEIM_API UHeightfieldService : public UObject, public IHeightfieldServiceInterface
 {
 	GENERATED_BODY()
 
 public:
 	UHeightfieldService();
 
-	// IHeightfieldService interface
+        // IHeightfieldServiceInterface
 	virtual bool Initialize(const FWorldGenConfig& Settings) override;
 	virtual FHeightfieldData GenerateHeightfield(uint64 Seed, FTileCoord TileCoord) override;
 	virtual bool ModifyHeightfield(FVector Location, float Radius, float Strength, EHeightfieldOperation Operation) override;

--- a/Source/Vibeheim/WorldGen/Public/Services/IHeightfieldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/IHeightfieldService.h
@@ -93,16 +93,16 @@ struct VIBEHEIM_API FHeightfieldData
 UINTERFACE(MinimalAPI, Blueprintable)
 class UHeightfieldServiceInterface : public UInterface
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 };
 
 /**
  * Interface for heightfield generation and management services
  * Handles terrain height generation, modification, and rendering integration
  */
-class VIBEHEIM_API IHeightfieldService
+class VIBEHEIM_API IHeightfieldServiceInterface
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
 	/**
@@ -183,5 +183,5 @@ public:
 	/**
 	 * Get performance statistics for heightfield generation
 	 */
-	virtual void GetPerformanceStats(float& OutAverageGenerationTimeMs, int32& OutCachedTiles) = 0;
+        virtual void GetPerformanceStats(float& OutAverageGenerationTimeMs, int32& OutCachedTiles) = 0;
 };

--- a/Source/Vibeheim/WorldGen/Public/Services/IPCGWorldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/IPCGWorldService.h
@@ -36,16 +36,16 @@ struct VIBEHEIM_API FPCGGenerationData
 UINTERFACE(MinimalAPI, Blueprintable)
 class UPCGWorldServiceInterface : public UInterface
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 };
 
 /**
  * Interface for PCG-based world content generation
  * Handles biome-specific content, POI placement, and HISM management
  */
-class VIBEHEIM_API IPCGWorldService
+class VIBEHEIM_API IPCGWorldServiceInterface
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
 	/**
@@ -96,5 +96,5 @@ public:
 	/**
 	 * Validate PCG graph compatibility
 	 */
-	virtual bool ValidatePCGGraph(const FString& GraphPath, TArray<FString>& OutErrors) = 0;
+        virtual bool ValidatePCGGraph(const FString& GraphPath, TArray<FString>& OutErrors) = 0;
 };

--- a/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
@@ -15,14 +15,14 @@ class UHierarchicalInstancedStaticMeshComponent;
  * Handles PCG-based content generation with fallback for non-PCG builds
  */
 UCLASS(BlueprintType)
-class VIBEHEIM_API UPCGWorldService : public UObject, public IPCGWorldService
+class VIBEHEIM_API UPCGWorldService : public UObject, public IPCGWorldServiceInterface
 {
 	GENERATED_BODY()
 
 public:
 	UPCGWorldService();
 
-	// IPCGWorldService interface
+        // IPCGWorldServiceInterface
 	virtual bool Initialize(const FWorldGenConfig& Settings) override;
 
 	virtual bool InitializePCGGraph(UObject* BiomeGraph) override;


### PR DESCRIPTION
## Summary
- rename IPCGWorldService to IPCGWorldServiceInterface and update users
- rename IHeightfieldService to IHeightfieldServiceInterface and update users

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a21cdec2a4832ab5f68b3694ddb412