### PR TITLE
Refine PCG tile sizing and terrain projection

### DIFF
--- a/Content/_Assets/Data/PCG/README.md
+++ b/Content/_Assets/Data/PCG/README.md
@@ -1,0 +1,6 @@
+# PCG Graph Authoring Notes
+
+* Mesh references **must** be authored as Soft Object Path attributes. Use the `Set Attribute` node, set the type to `Soft Object Path`, and provide the asset reference (e.g. `/Game/Foo/Bar.Bar`).
+* Supported attribute keys for meshes are `StaticMesh` or `Mesh`.
+* Avoid wiring `UStaticMesh*` or other pointer types. Pointer metadata cannot be blended and will fail validation.
+* Optional attribute `RespectGraphZ` (bool) controls whether runtime generation preserves the Z value authored in the graph. Leave unset or `false` to project instances onto the terrain automatically.

--- a/Source/Vibeheim/Vibeheim.cpp
+++ b/Source/Vibeheim/Vibeheim.cpp
@@ -3,4 +3,6 @@
 #include "Vibeheim.h"
 #include "Modules/ModuleManager.h"
 
+static_assert(ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 6, "Requires UE 5.6.x");
+
 IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, Vibeheim, "Vibeheim" );

--- a/Source/Vibeheim/WorldGen/Private/Services/HeightfieldService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/HeightfieldService.cpp
@@ -61,27 +61,30 @@ FHeightfieldData UHeightfieldService::GenerateHeightfield(int32 Seed, FTileCoord
 {
 	double StartTime = FPlatformTime::Seconds();
 
-	FHeightfieldData HeightfieldData;
-	HeightfieldData.TileCoord = TileCoord;
-	HeightfieldData.Resolution = 64; // Locked per coordinate system
+        FHeightfieldData HeightfieldData;
+        HeightfieldData.TileCoord = TileCoord;
 
-	// Calculate tile world position
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
+        const int32 SamplesPerTile = FMath::Clamp(FMath::RoundToInt(TileSize / FMath::Max(SampleSpacing, KINDA_SMALL_NUMBER)), 1, 4096);
+        HeightfieldData.Resolution = SamplesPerTile;
 
-	// Generate height data for 64x64 samples
-	const int32 SamplesPerTile = 64;
-	HeightfieldData.HeightData.Reserve(SamplesPerTile * SamplesPerTile);
+        // Calculate tile world position
+        FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+        FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
 
-	float MinHeight = FLT_MAX;
-	float MaxHeight = -FLT_MAX;
+        // Generate height data for SamplesPerTile x SamplesPerTile samples
+        HeightfieldData.HeightData.Reserve(SamplesPerTile * SamplesPerTile);
 
-	for (int32 Y = 0; Y < SamplesPerTile; Y++)
-	{
-		for (int32 X = 0; X < SamplesPerTile; X++)
-		{
-			FVector2D SampleWorldPos = TileStart + FVector2D(X, Y);
-			float Height = GenerateBaseHeight(SampleWorldPos, Seed);
+        float MinHeight = FLT_MAX;
+        float MaxHeight = -FLT_MAX;
+
+        for (int32 Y = 0; Y < SamplesPerTile; Y++)
+        {
+                for (int32 X = 0; X < SamplesPerTile; X++)
+                {
+                        FVector2D SampleWorldPos = TileStart + FVector2D(X * SampleSpacing, Y * SampleSpacing);
+                        float Height = GenerateBaseHeight(SampleWorldPos, Seed);
 
 			HeightfieldData.HeightData.Add(Height);
 			MinHeight = FMath::Min(MinHeight, Height);
@@ -186,14 +189,17 @@ FHeightfieldData UHeightfieldService::GenerateHeightfieldPristine(int32 Seed, FT
 
     FHeightfieldData HeightfieldData;
     HeightfieldData.TileCoord = TileCoord;
-    HeightfieldData.Resolution = 64; // Locked per coordinate system
+
+    const float TileSize = WorldGenSettings.TileSizeMeters;
+    const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
+    const int32 SamplesPerTile = FMath::Clamp(FMath::RoundToInt(TileSize / FMath::Max(SampleSpacing, KINDA_SMALL_NUMBER)), 1, 4096);
+    HeightfieldData.Resolution = SamplesPerTile;
 
     // Calculate tile world position
-    FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-    FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+    FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+    FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
 
-    // Generate height data for 64x64 samples
-    const int32 SamplesPerTile = 64;
+    // Generate height data for SamplesPerTile x SamplesPerTile samples
     HeightfieldData.HeightData.Reserve(SamplesPerTile * SamplesPerTile);
 
     float MinHeight = FLT_MAX;
@@ -203,7 +209,7 @@ FHeightfieldData UHeightfieldService::GenerateHeightfieldPristine(int32 Seed, FT
     {
         for (int32 X = 0; X < SamplesPerTile; X++)
         {
-            FVector2D SampleWorldPos = TileStart + FVector2D(X, Y);
+            FVector2D SampleWorldPos = TileStart + FVector2D(X * SampleSpacing, Y * SampleSpacing);
             float Height = GenerateBaseHeight(SampleWorldPos, Seed);
 
             HeightfieldData.HeightData.Add(Height);
@@ -687,7 +693,7 @@ bool UHeightfieldService::ModifyHeightfield(FVector Location, float Radius, floa
 	Modification.Radius = Radius;
 	Modification.Strength = Strength;
 	Modification.Operation = Operation;
-	Modification.AffectedTile = FTileCoord::FromWorldPosition(Location);
+        Modification.AffectedTile = FTileCoord::FromWorldPosition(Location, WorldGenSettings.TileSizeMeters);
 	Modification.Timestamp = FDateTime::Now();
 
 	// Persist derived parameters for bit-for-bit determinism
@@ -697,7 +703,7 @@ bool UHeightfieldService::ModifyHeightfield(FVector Location, float Radius, floa
 	if (Modification.Operation == EHeightfieldOperation::Flatten)
 	{
 		// Sample height at the center location from current heightfield
-		FTileCoord CenterTile = FTileCoord::FromWorldPosition(Location);
+                FTileCoord CenterTile = FTileCoord::FromWorldPosition(Location, WorldGenSettings.TileSizeMeters);
 		if (FHeightfieldData* CachedData = HeightfieldCache.Find(CenterTile))
 		{
 			Modification.FlattenTargetZ = SampleHeightAt(Modification.Center, CachedData->HeightData, CenterTile);
@@ -706,7 +712,7 @@ bool UHeightfieldService::ModifyHeightfield(FVector Location, float Radius, floa
 		else
 		{
 			// If no cached data, generate heightfield to sample from
-			FHeightfieldData TempHeightfield = GenerateHeightfield(0, CenterTile);
+                        FHeightfieldData TempHeightfield = GenerateHeightfield(0, CenterTile);
 			Modification.FlattenTargetZ = SampleHeightAt(Modification.Center, TempHeightfield.HeightData, CenterTile);
 			Modification.bFlattenUsesTarget = true;
 		}
@@ -724,10 +730,12 @@ bool UHeightfieldService::ModifyHeightfield(FVector Location, float Radius, floa
 
 	// Calculate all affected tiles (modifications can span multiple tiles)
 	TSet<FTileCoord> AffectedTiles;
-	FTileCoord CenterTile = FTileCoord::FromWorldPosition(Location);
+        FTileCoord CenterTile = FTileCoord::FromWorldPosition(Location, WorldGenSettings.TileSizeMeters);
 
-	// Calculate radius in tiles
-	int32 TileRadius = FMath::CeilToInt(Radius / 64.0f);
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+
+        // Calculate radius in tiles
+        int32 TileRadius = FMath::CeilToInt(Radius / FMath::Max(TileSize, KINDA_SMALL_NUMBER));
 
 	// Add all potentially affected tiles
 	for (int32 Y = CenterTile.Y - TileRadius; Y <= CenterTile.Y + TileRadius; Y++)
@@ -737,12 +745,12 @@ bool UHeightfieldService::ModifyHeightfield(FVector Location, float Radius, floa
 			FTileCoord TileCoord(X, Y);
 
 			// Check if this tile is actually within the modification radius
-			FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
+                        FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
 			FVector2D TileCenter(TileWorldPos.X, TileWorldPos.Y);
 			float DistanceToTile = FVector2D::Distance(Modification.Center, TileCenter);
 
 			// Include tile if it's within modification radius plus tile diagonal
-			float TileDiagonal = 64.0f * FMath::Sqrt(2.0f);
+                        float TileDiagonal = TileSize * FMath::Sqrt(2.0f);
 			if (DistanceToTile <= Radius + TileDiagonal)
 			{
 				AffectedTiles.Add(TileCoord);
@@ -795,20 +803,25 @@ float UHeightfieldService::GetHeightAtLocation(FVector2D WorldPos)
 FVector UHeightfieldService::GetNormalAtLocation(FVector2D WorldPos)
 {
 	// Simple implementation - could be improved with proper interpolation
-	FTileCoord TileCoord = FTileCoord::FromWorldPosition(FVector(WorldPos.X, WorldPos.Y, 0.0f));
+        FTileCoord TileCoord = FTileCoord::FromWorldPosition(FVector(WorldPos.X, WorldPos.Y, 0.0f), WorldGenSettings.TileSizeMeters);
 	FHeightfieldData HeightfieldData;
 
-	if (GetCachedHeightfield(TileCoord, HeightfieldData))
-	{
-		// Convert world position to tile-local coordinates
-		FVector TileWorldPos = TileCoord.ToWorldPosition();
-		FVector2D LocalPos = WorldPos - FVector2D(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+        if (GetCachedHeightfield(TileCoord, HeightfieldData))
+        {
+                const float TileSize = WorldGenSettings.TileSizeMeters;
+                const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
+                const float InvSampleSpacing = 1.0f / FMath::Max(SampleSpacing, KINDA_SMALL_NUMBER);
 
-		int32 X = FMath::Clamp(FMath::FloorToInt(LocalPos.X), 0, 63);
-		int32 Y = FMath::Clamp(FMath::FloorToInt(LocalPos.Y), 0, 63);
+                // Convert world position to tile-local coordinates
+                FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+                FVector2D LocalPos = WorldPos - FVector2D(TileWorldPos.X - TileSize * 0.5f,
+                        TileWorldPos.Y - TileSize * 0.5f);
 
-		return HeightfieldData.GetNormalAtSample(X, Y);
-	}
+                int32 X = FMath::Clamp(FMath::FloorToInt(LocalPos.X * InvSampleSpacing), 0, HeightfieldData.Resolution - 1);
+                int32 Y = FMath::Clamp(FMath::FloorToInt(LocalPos.Y * InvSampleSpacing), 0, HeightfieldData.Resolution - 1);
+
+                return HeightfieldData.GetNormalAtSample(X, Y);
+        }
 
 	return FVector::UpVector;
 }
@@ -818,16 +831,21 @@ float UHeightfieldService::GetSlopeAtLocation(FVector2D WorldPos)
 	FTileCoord TileCoord = FTileCoord::FromWorldPosition(FVector(WorldPos.X, WorldPos.Y, 0.0f));
 	FHeightfieldData HeightfieldData;
 
-	if (GetCachedHeightfield(TileCoord, HeightfieldData))
-	{
-		FVector TileWorldPos = TileCoord.ToWorldPosition();
-		FVector2D LocalPos = WorldPos - FVector2D(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+        if (GetCachedHeightfield(TileCoord, HeightfieldData))
+        {
+                const float TileSize = WorldGenSettings.TileSizeMeters;
+                const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
+                const float InvSampleSpacing = 1.0f / FMath::Max(SampleSpacing, KINDA_SMALL_NUMBER);
 
-		int32 X = FMath::Clamp(FMath::FloorToInt(LocalPos.X), 0, 63);
-		int32 Y = FMath::Clamp(FMath::FloorToInt(LocalPos.Y), 0, 63);
+                FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+                FVector2D LocalPos = WorldPos - FVector2D(TileWorldPos.X - TileSize * 0.5f,
+                        TileWorldPos.Y - TileSize * 0.5f);
 
-		return HeightfieldData.GetSlopeAtSample(X, Y);
-	}
+                int32 X = FMath::Clamp(FMath::FloorToInt(LocalPos.X * InvSampleSpacing), 0, HeightfieldData.Resolution - 1);
+                int32 Y = FMath::Clamp(FMath::FloorToInt(LocalPos.Y * InvSampleSpacing), 0, HeightfieldData.Resolution - 1);
+
+                return HeightfieldData.GetSlopeAtSample(X, Y);
+        }
 
 	return 0.0f;
 }
@@ -941,20 +959,26 @@ void UHeightfieldService::SetNoiseSystem(UNoiseSystem* InNoiseSystem)
 
 float UHeightfieldService::InterpolateHeight(FVector2D WorldPos) const
 {
-	FTileCoord TileCoord = FTileCoord::FromWorldPosition(FVector(WorldPos.X, WorldPos.Y, 0.0f));
+        FTileCoord TileCoord = FTileCoord::FromWorldPosition(FVector(WorldPos.X, WorldPos.Y, 0.0f), WorldGenSettings.TileSizeMeters);
 
-	if (const FHeightfieldData* CachedData = HeightfieldCache.Find(TileCoord))
-	{
-		FVector TileWorldPos = TileCoord.ToWorldPosition();
-		FVector2D LocalPos = WorldPos - FVector2D(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+        if (const FHeightfieldData* CachedData = HeightfieldCache.Find(TileCoord))
+        {
+                const float TileSize = WorldGenSettings.TileSizeMeters;
+                const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
+                const float InvSampleSpacing = 1.0f / FMath::Max(SampleSpacing, KINDA_SMALL_NUMBER);
+                const int32 Resolution = CachedData->Resolution;
 
-		int32 X = FMath::Clamp(FMath::FloorToInt(LocalPos.X), 0, 63);
-		int32 Y = FMath::Clamp(FMath::FloorToInt(LocalPos.Y), 0, 63);
+                FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+                FVector2D LocalPos = WorldPos - FVector2D(TileWorldPos.X - TileSize * 0.5f,
+                        TileWorldPos.Y - TileSize * 0.5f);
 
-		return CachedData->GetHeightAtSample(X, Y);
-	}
+                int32 X = FMath::Clamp(FMath::FloorToInt(LocalPos.X * InvSampleSpacing), 0, Resolution - 1);
+                int32 Y = FMath::Clamp(FMath::FloorToInt(LocalPos.Y * InvSampleSpacing), 0, Resolution - 1);
 
-	return 0.0f;
+                return CachedData->GetHeightAtSample(X, Y);
+        }
+
+        return 0.0f;
 }
 
 void UHeightfieldService::ApplyModificationToCache(const FHeightfieldModification& Modification)
@@ -970,9 +994,12 @@ void UHeightfieldService::ApplyModificationToCache(const FHeightfieldModificatio
 	}
 
 	// Calculate tile world bounds
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
-	FVector2D TileEnd(TileWorldPos.X + 32.0f, TileWorldPos.Y + 32.0f);
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
+
+        FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+        FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
+        FVector2D TileEnd(TileWorldPos.X + TileSize * 0.5f, TileWorldPos.Y + TileSize * 0.5f);
 
 	// Skip if modification is outside this tile
 	if (Modification.Center.X + Modification.Radius < TileStart.X ||
@@ -983,9 +1010,8 @@ void UHeightfieldService::ApplyModificationToCache(const FHeightfieldModificatio
 		return;
 	}
 
-	const int32 Resolution = CachedData->Resolution;
-	const float SampleSpacing = 1.0f; // 1m per sample
-	bool bDataModified = false;
+        const int32 Resolution = CachedData->Resolution;
+        bool bDataModified = false;
 
 	// For smooth operations, create a snapshot of the current state
 	TArray<float> HeightSnapshot;
@@ -1000,7 +1026,7 @@ void UHeightfieldService::ApplyModificationToCache(const FHeightfieldModificatio
 		for (int32 X = 0; X < Resolution; X++)
 		{
 			// Calculate world position of this sample
-			FVector2D SampleWorldPos = TileStart + FVector2D(X * SampleSpacing, Y * SampleSpacing);
+                        FVector2D SampleWorldPos = TileStart + FVector2D(X * SampleSpacing, Y * SampleSpacing);
 
 			// Calculate distance from modification center
 			float Distance = FVector2D::Distance(SampleWorldPos, Modification.Center);
@@ -1149,8 +1175,8 @@ void UHeightfieldService::ClearVegetationInArea(FVector2D Center, float Radius)
 	// For now, we just log the action as a placeholder for the integration
 
 	// Calculate affected tiles
-	FTileCoord CenterTile = FTileCoord::FromWorldPosition(FVector(Center.X, Center.Y, 0.0f));
-	int32 TileRadius = FMath::CeilToInt(Radius / 64.0f); // 64m per tile
+        FTileCoord CenterTile = FTileCoord::FromWorldPosition(FVector(Center.X, Center.Y, 0.0f), WorldGenSettings.TileSizeMeters);
+        int32 TileRadius = FMath::CeilToInt(Radius / FMath::Max(WorldGenSettings.TileSizeMeters, KINDA_SMALL_NUMBER));
 
 	UE_LOG(LogHeightfieldService, Log, TEXT("Clearing vegetation in area centered at (%.1f, %.1f) with radius %.1f - affects ~%d tiles"),
 		Center.X, Center.Y, Radius, (TileRadius * 2 + 1) * (TileRadius * 2 + 1));
@@ -1551,12 +1577,13 @@ void UHeightfieldService::ApplyModificationsToTile(FTileCoord TileCoord, TArray<
 	UE_LOG(LogHeightfieldService, Log, TEXT("ApplyModificationsToTile: Applying %d modifications to tile (%d, %d), initial checksum: 0x%08X"),
 		ModList->Modifications.Num(), TileCoord.X, TileCoord.Y, InitialChecksum);
 
-	// Calculate tile world bounds
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+        // Calculate tile world bounds
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
+        const int32 Resolution = FMath::Clamp(FMath::RoundToInt(TileSize / FMath::Max(SampleSpacing, KINDA_SMALL_NUMBER)), 1, 4096);
 
-	const int32 Resolution = 64; // Locked per coordinate system
-	const float SampleSpacing = 1.0f; // 1m per sample
+        FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+        FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
 
     // First: GUID-based dedup (preserve first-seen order)
     TArray<FHeightfieldModification> UniqueModifications;
@@ -1629,7 +1656,7 @@ void UHeightfieldService::ApplyModificationsToTile(FTileCoord TileCoord, TArray<
 			for (int32 X = 0; X < Resolution; X++)
 			{
 				// Calculate world position of this sample
-				FVector2D SampleWorldPos = TileStart + FVector2D(X * SampleSpacing, Y * SampleSpacing);
+                        FVector2D SampleWorldPos = TileStart + FVector2D(X * SampleSpacing, Y * SampleSpacing);
 
 				// Calculate distance from modification center
 				float Distance = FVector2D::Distance(SampleWorldPos, Modification.Center);
@@ -1727,12 +1754,13 @@ void UHeightfieldService::ApplyModificationsToTile(FTileCoord TileCoord, TArray<
 
 void UHeightfieldService::ApplyModificationToHeightfield(FHeightfieldData& HeightfieldData, const FHeightfieldModification& Modification)
 {
-	// Calculate tile world bounds
-	FVector TileWorldPos = HeightfieldData.TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+        // Calculate tile world bounds
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
+        FVector TileWorldPos = HeightfieldData.TileCoord.ToWorldPosition(TileSize);
+        FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
 
-	const int32 Resolution = HeightfieldData.Resolution;
-	const float SampleSpacing = 1.0f; // 1m per sample
+        const int32 Resolution = HeightfieldData.Resolution;
 	bool bDataModified = false;
 
 	// For smooth operations, create a snapshot of the current state
@@ -1859,28 +1887,29 @@ void UHeightfieldService::ApplyModificationToHeightfield(FHeightfieldData& Heigh
 
 float UHeightfieldService::SampleHeightAt(FVector2D WorldXY, const TArray<float>& HeightData, FTileCoord TileCoord) const
 {
-	// Consistent coordinate conversion (cm → sample index)
-	const float SampleSpacing = 100.0f; // 1m per sample in cm
-	const float TileSize = 64.0f * 100.0f; // 64m tile size in cm
-	const int32 GridSize = 64; // Fixed resolution
+        // Consistent coordinate conversion (cm → sample index)
+        const float SampleSpacingCm = WorldGenSettings.SampleSpacingMeters * 100.0f;
+        const float TileSizeCm = WorldGenSettings.TileSizeMeters * 100.0f;
+        const int32 GridSize = FMath::Clamp(FMath::RoundToInt(WorldGenSettings.TileSizeMeters /
+                FMath::Max(WorldGenSettings.SampleSpacingMeters, KINDA_SMALL_NUMBER)), 1, 4096);
 
-	// Calculate tile origin in world coordinates (cm)
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileOrigin(TileWorldPos.X * 100.0f - TileSize * 0.5f, TileWorldPos.Y * 100.0f - TileSize * 0.5f);
+        // Calculate tile origin in world coordinates (cm)
+        FVector TileWorldPos = TileCoord.ToWorldPosition(WorldGenSettings.TileSizeMeters);
+        FVector2D TileOrigin(TileWorldPos.X * 100.0f - TileSizeCm * 0.5f, TileWorldPos.Y * 100.0f - TileSizeCm * 0.5f);
 
-	// Convert world position to local tile coordinates
-	FVector2D LocalPos = (WorldXY * 100.0f - TileOrigin) / SampleSpacing;
+        // Convert world position to local tile coordinates
+        FVector2D LocalPos = (WorldXY * 100.0f - TileOrigin) / FMath::Max(SampleSpacingCm, KINDA_SMALL_NUMBER);
 
-	// Clamp to valid sample range
-	float Fx = FMath::Clamp(LocalPos.X, 0.0f, GridSize - 1.0f);
-	float Fy = FMath::Clamp(LocalPos.Y, 0.0f, GridSize - 1.0f);
+        // Clamp to valid sample range
+        float Fx = FMath::Clamp(LocalPos.X, 0.0f, GridSize - 1.0f);
+        float Fy = FMath::Clamp(LocalPos.Y, 0.0f, GridSize - 1.0f);
 
 	// Get integer indices
 	int32 Ix = FMath::FloorToInt(Fx);
 	int32 Iy = FMath::FloorToInt(Fy);
 
 	// Bilinear interpolation for smoother sampling
-	if (Ix < GridSize - 1 && Iy < GridSize - 1)
+        if (Ix < GridSize - 1 && Iy < GridSize - 1)
 	{
 		float FracX = Fx - Ix;
 		float FracY = Fy - Iy;

--- a/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
@@ -37,6 +37,7 @@
 #include "HAL/IConsoleManager.h"
 #include "HAL/FileManager.h"
 #include "Trace/Trace.inl"
+#include "Services/HeightfieldService.h"
 
 UE_DEFINE_LOG_CATEGORY(LogPCGWorldService);
 
@@ -385,6 +386,7 @@ namespace PCGWorldService::Private
             { VHMPCGAttr::SeaLevel, TConstArrayView<EPCGMetadataTypes>(FloatType, UE_ARRAY_COUNT(FloatType)), EAttributeScope::Parameter, true, TEXT("float") },
             { VHMPCGAttr::TileSize, TConstArrayView<EPCGMetadataTypes>(FloatType, UE_ARRAY_COUNT(FloatType)), EAttributeScope::Parameter, true, TEXT("float") },
             { VHMPCGAttr::BiomeWeight, TConstArrayView<EPCGMetadataTypes>(FloatType, UE_ARRAY_COUNT(FloatType)), EAttributeScope::Parameter, true, TEXT("float") },
+            { VHMPCGAttr::DensityScale, TConstArrayView<EPCGMetadataTypes>(FloatType, UE_ARRAY_COUNT(FloatType)), EAttributeScope::Parameter, false, TEXT("float") },
             { VHMPCGAttr::BiomeId, TConstArrayView<EPCGMetadataTypes>(Int32Type, UE_ARRAY_COUNT(Int32Type)), EAttributeScope::Parameter, true, TEXT("int32") },
             { VHMPCGAttr::TileSeed, TConstArrayView<EPCGMetadataTypes>(Int32Type, UE_ARRAY_COUNT(Int32Type)), EAttributeScope::Parameter, true, TEXT("int32") },
             { VHMPCGAttr::TileX, TConstArrayView<EPCGMetadataTypes>(Int32Type, UE_ARRAY_COUNT(Int32Type)), EAttributeScope::Parameter, true, TEXT("int32") },
@@ -395,7 +397,8 @@ namespace PCGWorldService::Private
             { VHMPCGAttr::InstanceScale, TConstArrayView<EPCGMetadataTypes>(VectorType, UE_ARRAY_COUNT(VectorType)), EAttributeScope::Point, false, TEXT("FVector") },
             { VHMPCGAttr::InstanceRotation, TConstArrayView<EPCGMetadataTypes>(RotatorType, UE_ARRAY_COUNT(RotatorType)), EAttributeScope::Point, false, TEXT("FRotator") },
             { VHMPCGAttr::IsActive, TConstArrayView<EPCGMetadataTypes>(BoolType, UE_ARRAY_COUNT(BoolType)), EAttributeScope::Point, false, TEXT("bool") },
-            { VHMPCGAttr::InstanceId, TConstArrayView<EPCGMetadataTypes>(GuidType, UE_ARRAY_COUNT(GuidType)), EAttributeScope::Point, false, TEXT("FGuid (stored as string/name)") }
+            { VHMPCGAttr::InstanceId, TConstArrayView<EPCGMetadataTypes>(GuidType, UE_ARRAY_COUNT(GuidType)), EAttributeScope::Point, false, TEXT("FGuid (stored as string/name)") },
+            { VHMPCGAttr::RespectGraphZ, TConstArrayView<EPCGMetadataTypes>(BoolType, UE_ARRAY_COUNT(BoolType)), EAttributeScope::Point, false, TEXT("bool") }
         };
 
         return Attributes;
@@ -447,12 +450,14 @@ namespace PCGWorldService::Private
     }
 
 static UPCGParamData* CreateTileParameterData(UObject* Outer, const FPCGTileMetrics& TileMetrics,
-                FTileCoord TileCoord, EBiomeType BiomeType, const FWorldGenConfig& WorldGenSettings, uint32 TileSeed);
+                FTileCoord TileCoord, EBiomeType BiomeType, const FWorldGenConfig& WorldGenSettings, uint32 TileSeed,
+                float DensityScale);
 
         static UPCGPointData* CreateTilePointData(UObject* Outer, FTileCoord TileCoord, const FWorldGenConfig& WorldGenSettings,
                 const FPCGTileMetrics& TileMetrics);
 
         static void ExtractInstancesFromPointData(const UPCGPointData* PointData, FTileCoord TileCoord,
+                const FWorldGenConfig& WorldGenSettings, const UHeightfieldService* HeightfieldService,
                 FPCGGenerationData& OutGenerationData);
 }
 #endif
@@ -463,10 +468,11 @@ UPCGWorldService::UPCGWorldService()
         PerformanceStats = FPCGPerformanceStats();
         CurrentPCGGraph = nullptr;
         TileActor = nullptr;
+        HeightfieldService = nullptr;
         MaxInstancesPerTile = 10000;
-        LODDistances.Add(500.0f);  // LOD 0-1 transition
-        LODDistances.Add(1500.0f); // LOD 1-2 transition
-        LODDistances.Add(5000.0f); // LOD 2-3 transition
+        CullDistances.Add(500.0f);  // Near cull distance for runtime HISM fallback
+        CullDistances.Add(1500.0f); // Mid-range cull distance for runtime HISM fallback
+        CullDistances.Add(5000.0f); // Far cull distance for runtime HISM fallback
 #if VHM_PCG_ENABLED
     SchedulerExecutor = MakeUnique<FPCGSchedulerExecutor>();
     RefreshRuntimeSettingsFromCVars();
@@ -999,7 +1005,7 @@ void UPCGWorldService::HandleWorldCleanup(UWorld* World, bool bSessionEnded, boo
 #if VHM_PCG_ENABLED
 UPCGParamData* PCGWorldService::Private::CreateTileParameterData(UObject* Outer,
         const FPCGTileMetrics& TileMetrics, FTileCoord TileCoord, EBiomeType BiomeType,
-        const FWorldGenConfig& WorldGenSettings, uint32 TileSeed)
+        const FWorldGenConfig& WorldGenSettings, uint32 TileSeed, float DensityScale)
 {
         UPCGParamData* ParamData = NewObject<UPCGParamData>(Outer ? Outer : GetTransientPackage(), NAME_None, RF_Transient);
         if (!ensureMsgf(ParamData, TEXT("Failed to allocate tile parameter data for (%d, %d)"), TileCoord.X, TileCoord.Y))
@@ -1053,6 +1059,7 @@ UPCGParamData* PCGWorldService::Private::CreateTileParameterData(UObject* Outer,
         EnsureAndSetAttribute(VHMPCGAttr::TileY, TileCoord.Y, false);
         EnsureAndSetAttribute(VHMPCGAttr::TileSize, WorldGenSettings.TileSizeMeters, true);
         EnsureAndSetAttribute(VHMPCGAttr::BiomeWeight, 1.0f, true);
+        EnsureAndSetAttribute(VHMPCGAttr::DensityScale, DensityScale, true);
 
         return ParamData;
 }
@@ -1111,6 +1118,7 @@ UPCGPointData* PCGWorldService::Private::CreateTilePointData(UObject* Outer, FTi
 }
 
 void PCGWorldService::Private::ExtractInstancesFromPointData(const UPCGPointData* PointData, FTileCoord TileCoord,
+        const FWorldGenConfig& WorldGenSettings, const UHeightfieldService* HeightfieldService,
         FPCGGenerationData& OutGenerationData)
 {
         OutGenerationData.GeneratedInstances.Reset();
@@ -1135,6 +1143,10 @@ void PCGWorldService::Private::ExtractInstancesFromPointData(const UPCGPointData
         }
 
         OutGenerationData.GeneratedInstances.Reserve(Points.Num());
+
+        const float MinTerrainZ = WorldGenSettings.SeaLevel - WorldGenSettings.MaxTerrainHeight;
+        const float MaxTerrainZ = WorldGenSettings.SeaLevel + WorldGenSettings.MaxTerrainHeight;
+        bool bLoggedMissingHeightService = false;
 
         bool bLoggedMissingMetadata = false;
         TSet<FName> MissingAttributes;
@@ -1186,6 +1198,7 @@ void PCGWorldService::Private::ExtractInstancesFromPointData(const UPCGPointData
                 Instance.OwningTile = TileCoord;
 
                 const PCGMetadataEntryKey EntryKey = Point.MetadataEntry;
+                bool bRespectGraphZ = false;
 
                 if (!Metadata)
                 {
@@ -1223,22 +1236,22 @@ void PCGWorldService::Private::ExtractInstancesFromPointData(const UPCGPointData
                                 Instance.Mesh = TSoftObjectPtr<UStaticMesh>(StaticMeshPath);
                                 bMeshAssigned = true;
                         }
-                        else
-                        {
-                                UObject* RawObject = nullptr;
-                                if (Metadata->GetAttribute<UObject*>(VHMPCGAttr::StaticMesh, EntryKey, RawObject) || Metadata->GetAttribute<UObject*>(VHMPCGAttr::Mesh, EntryKey, RawObject))
-                                {
-                                        if (UStaticMesh* MeshAsset = Cast<UStaticMesh>(RawObject))
-                                        {
-                                                Instance.Mesh = MeshAsset;
-                                                bMeshAssigned = true;
-                                        }
-                                }
-                        }
-
                         if (!bMeshAssigned)
                         {
-                                LogMissingAttribute(VHMPCGAttr::StaticMesh);
+                                const bool bHasStaticMeshAttr = Metadata->GetConstAttribute(VHMPCGAttr::StaticMesh) != nullptr;
+                                const bool bHasMeshAttr = Metadata->GetConstAttribute(VHMPCGAttr::Mesh) != nullptr;
+
+                                if (!bHasStaticMeshAttr && !bHasMeshAttr)
+                                {
+                                        LogMissingAttribute(VHMPCGAttr::StaticMesh);
+                                }
+                                else
+                                {
+                                        const FName AttrName = bHasStaticMeshAttr ? VHMPCGAttr::StaticMesh : VHMPCGAttr::Mesh;
+                                        UE_LOG(LogPCGWorldService, Error,
+                                                TEXT("Tile (%d, %d) attribute '%s' must be authored as a Soft Object Path."),
+                                                TileCoord.X, TileCoord.Y, *AttrName.ToString());
+                                }
                         }
 
                         bool bIsActive = Instance.bIsActive;
@@ -1285,7 +1298,31 @@ void PCGWorldService::Private::ExtractInstancesFromPointData(const UPCGPointData
                                         LogMissingAttribute(VHMPCGAttr::InstanceId);
                                 }
                         }
+
+                        Metadata->GetAttribute<bool>(VHMPCGAttr::RespectGraphZ, EntryKey, bRespectGraphZ);
                 }
+
+                const bool bZOutOfBounds = (Instance.Location.Z < MinTerrainZ || Instance.Location.Z > MaxTerrainZ);
+                if (!bRespectGraphZ || bZOutOfBounds)
+                {
+                        if (HeightfieldService)
+                        {
+                                const float TerrainHeight = HeightfieldService->GetHeightAtLocation(FVector2D(Instance.Location.X, Instance.Location.Y));
+                                if (FMath::IsFinite(TerrainHeight))
+                                {
+                                        Instance.Location.Z = TerrainHeight;
+                                }
+                        }
+                        else if (!bLoggedMissingHeightService)
+                        {
+                                UE_LOG(LogPCGWorldService, Warning,
+                                        TEXT("Heightfield service unavailable; cannot project PCG instances for tile (%d, %d)."),
+                                        TileCoord.X, TileCoord.Y);
+                                bLoggedMissingHeightService = true;
+                        }
+                }
+
+                Instance.Location.Z = FMath::Clamp(Instance.Location.Z, MinTerrainZ, MaxTerrainZ);
 
                 OutGenerationData.GeneratedInstances.Add(MoveTemp(Instance));
         }
@@ -1441,10 +1478,6 @@ bool UPCGWorldService::Initialize(const FWorldGenConfig& Settings)
         MaxInstancesPerTile = Settings.MaxHISMInstances;
         InitializeDefaultBiomes();
 
-        WorldGenSettings = Settings;
-        MaxInstancesPerTile = Settings.MaxHISMInstances;
-        InitializeDefaultBiomes();
-
 #if WITH_AUTOMATION_TESTS && VHM_PCG_ENABLED
         if (TestWorldOverride.IsValid())
         {
@@ -1526,10 +1559,11 @@ FPCGGenerationData UPCGWorldService::GenerateBiomeContent(FTileCoord TileCoord, 
 #endif
 
 	// Add logging during content test to verify rule count
-	if (const FBiomeDefinition* BiomeDef = BiomeDefinitions.Find(BiomeType))
-	{
-		UE_LOG(LogPCGWorldService, Log, TEXT("Forest rules: N=%d"), BiomeDef->VegetationRules.Num());
-	}
+        if (const FBiomeDefinition* BiomeDef = BiomeDefinitions.Find(BiomeType))
+        {
+                UE_LOG(LogPCGWorldService, Log, TEXT("%s rules: N=%d"),
+                        *UEnum::GetValueAsString(BiomeType), BiomeDef->VegetationRules.Num());
+        }
 
 	// For biome-specific generation (test path), dont use cache - always generate fresh
 	// This ensures we use the BiomeType parameter as authoritative rather than tile classification
@@ -1558,7 +1592,9 @@ FPCGGenerationData UPCGWorldService::GenerateContentInternal(FTileCoord TileCoor
 {
         FPCGTileMetrics TileMetrics;
         bool bHasTileMetrics = false;
-        const int32 ExpectedHeightDataSize = 64 * 64;
+        const float SamplesPerSideFloat = WorldGenSettings.TileSizeMeters / FMath::Max(KINDA_SMALL_NUMBER, WorldGenSettings.SampleSpacingMeters);
+        const int32 SamplesPerSide = FMath::Clamp(FMath::RoundToInt(SamplesPerSideFloat), 1, 4096);
+        const int32 ExpectedHeightDataSize = SamplesPerSide * SamplesPerSide;
 
 #if VHM_PCG_ENABLED
         if (bDedicatedServer || bHeadless)
@@ -1714,7 +1750,9 @@ FPCGGenerationData UPCGWorldService::GeneratePCGContent(FTileCoord TileCoord, EB
         return GenerateFallbackContent(TileCoord, BiomeType, HeightData, true, TileMetrics);
     }
 
-    const int32 ExpectedHeightSamples = 64 * 64;
+    const float SamplesPerSideFloat = WorldGenSettings.TileSizeMeters / FMath::Max(KINDA_SMALL_NUMBER, WorldGenSettings.SampleSpacingMeters);
+    const int32 SamplesPerSide = FMath::Clamp(FMath::RoundToInt(SamplesPerSideFloat), 1, 4096);
+    const int32 ExpectedHeightSamples = SamplesPerSide * SamplesPerSide;
     const bool bHasHeightData = HeightData.Num() == ExpectedHeightSamples;
 
     FPCGTileMetrics LocalMetrics;
@@ -1725,9 +1763,14 @@ FPCGGenerationData UPCGWorldService::GeneratePCGContent(FTileCoord TileCoord, EB
         EffectiveMetrics = &LocalMetrics;
     }
 
+    const float EstimatedWorkUnits = EstimateWorkUnitsForBiome(BiomeType, EffectiveMetrics);
+    const float DensityScale = ComputeDensityScaleFromWork(EstimatedWorkUnits);
+    GenerationData.EstimatedWorkUnits = EstimatedWorkUnits;
+    GenerationData.DensityScale = DensityScale;
+
     const uint32 TileSeed = GetTileRandomSeed(TileCoord);
     UObject* DataOuter = AnchorActor ? static_cast<UObject*>(AnchorActor) : static_cast<UObject*>(this);
-    UPCGParamData* ParameterData = Private::CreateTileParameterData(DataOuter, EffectiveMetrics ? *EffectiveMetrics : FPCGTileMetrics(), TileCoord, BiomeType, WorldGenSettings, TileSeed);
+    UPCGParamData* ParameterData = Private::CreateTileParameterData(DataOuter, EffectiveMetrics ? *EffectiveMetrics : FPCGTileMetrics(), TileCoord, BiomeType, WorldGenSettings, TileSeed, DensityScale);
     UPCGPointData* TilePointData = Private::CreateTilePointData(DataOuter, TileCoord, WorldGenSettings, EffectiveMetrics ? *EffectiveMetrics : FPCGTileMetrics());
 
     FAttributeValidationResult Validation = ValidateInputAttributes(ParameterData, TilePointData);
@@ -1846,7 +1889,8 @@ FPCGGenerationData UPCGWorldService::GeneratePCGContent(FTileCoord TileCoord, EB
     {
         if (const UPCGPointData* OutputPointData = Cast<UPCGPointData>(OutputDatum.Get()))
         {
-            Private::ExtractInstancesFromPointData(OutputPointData, TileCoord, GenerationData);
+            Private::ExtractInstancesFromPointData(OutputPointData, TileCoord, WorldGenSettings,
+                    HeightfieldService.Get(), GenerationData);
         }
     }
 
@@ -1898,8 +1942,10 @@ FPCGGenerationData UPCGWorldService::GenerateFallbackContent(FTileCoord TileCoor
 		return GenerationData;
 	}
 
-	const int32 ExpectedHeightDataSize = 64 * 64;
-	const bool bHasValidHeightData = HeightData.Num() == ExpectedHeightDataSize;
+        const float SamplesPerSideFloat = WorldGenSettings.TileSizeMeters / FMath::Max(KINDA_SMALL_NUMBER, WorldGenSettings.SampleSpacingMeters);
+        const int32 SamplesPerSide = FMath::Clamp(FMath::RoundToInt(SamplesPerSideFloat), 1, 4096);
+        const int32 ExpectedHeightDataSize = SamplesPerSide * SamplesPerSide;
+        const bool bHasValidHeightData = HeightData.Num() == ExpectedHeightDataSize;
 
 	FPCGTileMetrics LocalMetrics;
 	const FPCGTileMetrics* EffectiveMetrics = TileMetrics;
@@ -1933,7 +1979,12 @@ FPCGGenerationData UPCGWorldService::GenerateFallbackContent(FTileCoord TileCoor
 			*UEnum::GetValueAsString(BiomeType), EffectiveMetrics ? TEXT("true") : TEXT("false"));
 	}
 
-	TArray<FPCGInstanceData> VegetationInstances = GenerateVegetationInstances(TileCoord, *BiomeDef, HeightData, SpawnParams, EffectiveMetrics, bUsePCGHeuristics);
+        const float EstimatedWorkUnits = EstimateWorkUnitsForBiome(BiomeType, EffectiveMetrics);
+        const float DensityScale = ComputeDensityScaleFromWork(EstimatedWorkUnits);
+        GenerationData.EstimatedWorkUnits = EstimatedWorkUnits;
+        GenerationData.DensityScale = DensityScale;
+
+        TArray<FPCGInstanceData> VegetationInstances = GenerateVegetationInstances(TileCoord, *BiomeDef, HeightData, SpawnParams, EffectiveMetrics, bUsePCGHeuristics, DensityScale);
 	GenerationData.GeneratedInstances.Append(VegetationInstances);
 
 	TArray<FPOIData> POIInstances = GeneratePOIInstances(TileCoord, *BiomeDef, HeightData);
@@ -1957,31 +2008,35 @@ FPCGGenerationData UPCGWorldService::GenerateFallbackContent(FTileCoord TileCoor
 	return GenerationData;
 }
 
-TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoord TileCoord, const FBiomeDefinition& BiomeDef, const TArray<float>& HeightData, const FPCGTileMetrics* TileMetrics, bool bUsePCGHeuristics)
+TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoord TileCoord, const FBiomeDefinition& BiomeDef, const TArray<float>& HeightData, const FPCGTileMetrics* TileMetrics, bool bUsePCGHeuristics, float DensityScale)
 {
-	FPCGSpawnParams DefaultSpawnParams;
-	return GenerateVegetationInstances(TileCoord, BiomeDef, HeightData, DefaultSpawnParams, TileMetrics, bUsePCGHeuristics);
+        FPCGSpawnParams DefaultSpawnParams;
+        return GenerateVegetationInstances(TileCoord, BiomeDef, HeightData, DefaultSpawnParams, TileMetrics, bUsePCGHeuristics, DensityScale);
 }
 
-TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoord TileCoord, const FBiomeDefinition& BiomeDef, const TArray<float>& HeightData, const FPCGSpawnParams& SpawnParams, const FPCGTileMetrics* TileMetrics, bool bUsePCGHeuristics)
+TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoord TileCoord, const FBiomeDefinition& BiomeDef, const TArray<float>& HeightData, const FPCGSpawnParams& SpawnParams, const FPCGTileMetrics* TileMetrics, bool bUsePCGHeuristics, float DensityScale)
 {
-	TArray<FPCGInstanceData> Instances;
+        TArray<FPCGInstanceData> Instances;
 
-	const int32 ExpectedHeightDataSize = 64 * 64;
-	if (HeightData.Num() != ExpectedHeightDataSize)
-	{
-		UE_LOG(LogPCGWorldService, Error, TEXT("Height data size mismatch: expected %d elements (64x64), got %d elements"),
-			ExpectedHeightDataSize, HeightData.Num());
-		return Instances;
-	}
+        const float SamplesPerSideFloat = WorldGenSettings.TileSizeMeters / FMath::Max(KINDA_SMALL_NUMBER, WorldGenSettings.SampleSpacingMeters);
+        const int32 SamplesPerSide = FMath::Clamp(FMath::RoundToInt(SamplesPerSideFloat), 1, 4096);
+        const int32 ExpectedHeightDataSize = SamplesPerSide * SamplesPerSide;
+        if (HeightData.Num() != ExpectedHeightDataSize)
+        {
+                UE_LOG(LogPCGWorldService, Error, TEXT("Height data size mismatch: expected %d elements (%dx%d), got %d elements"),
+                        ExpectedHeightDataSize, HeightData.Num());
+                return Instances;
+        }
 
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
-	const float TileAreaM2 = 64.0f * 64.0f;
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float InvSampleSpacing = 1.0f / FMath::Max(KINDA_SMALL_NUMBER, WorldGenSettings.SampleSpacingMeters);
+        FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+        FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
+        const float TileAreaM2 = TileSize * TileSize;
 
-	FRandomStream RandomStream(GetTileRandomSeed(TileCoord));
-	const float BiomeWeight = GetBiomeWeightForSpawn(SpawnParams, BiomeDef.BiomeType);
-	const bool bApplyHeuristics = bUsePCGHeuristics && TileMetrics != nullptr;
+        FRandomStream RandomStream(GetTileRandomSeed(TileCoord));
+        const float BiomeWeight = GetBiomeWeightForSpawn(SpawnParams, BiomeDef.BiomeType);
+        const bool bApplyHeuristics = bUsePCGHeuristics && TileMetrics != nullptr;
 
 	UE_LOG(LogPCGWorldService, VeryVerbose, TEXT("Generating vegetation for biome %s with %d rules (heuristics=%s, biomeWeight=%.3f)"),
 		*UEnum::GetValueAsString(BiomeDef.BiomeType), BiomeDef.VegetationRules.Num(), bApplyHeuristics ? TEXT("true") : TEXT("false"), BiomeWeight);
@@ -1992,17 +2047,17 @@ TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoor
 	{
 		UStaticMesh* Mesh = VegRule.VegetationMesh.IsNull() ? nullptr : VegRule.VegetationMesh.LoadSynchronous();
 
-		float BaseDensity = VegRule.Density * WorldGenSettings.VegetationDensity * BiomeWeight;
-		if (TileMetrics)
-		{
-			BaseDensity *= ComputeEnvironmentScale(*TileMetrics, VegRule);
-		}
+                float BaseDensity = VegRule.Density * WorldGenSettings.VegetationDensity * BiomeWeight * DensityScale;
+                if (TileMetrics)
+                {
+                        BaseDensity *= ComputeEnvironmentScale(*TileMetrics, VegRule);
+                }
 
-		int32 BaseInstanceCount = FMath::Max(0, FMath::RoundToInt(BaseDensity * TileAreaM2 / 100.0f));
-		const int32 MaxInstancesForThisRule = FMath::Max(1, MaxInstancesPerTile / FMath::Max(1, BiomeDef.VegetationRules.Num()));
-		int32 InstanceCount = FMath::Min(BaseInstanceCount, MaxInstancesForThisRule);
+                int32 BaseInstanceCount = FMath::Max(0, FMath::RoundToInt(BaseDensity * TileAreaM2 / 100.0f));
+                const int32 MaxInstancesForThisRule = FMath::Max(1, MaxInstancesPerTile / FMath::Max(1, BiomeDef.VegetationRules.Num()));
+                int32 InstanceCount = FMath::Min(BaseInstanceCount, MaxInstancesForThisRule);
 
-		if (bHeadless && SpawnParams.bForceBiome)
+                if (bHeadless && SpawnParams.bForceBiome)
 		{
 			InstanceCount = FMath::Max(InstanceCount, 1);
 		}
@@ -2018,43 +2073,44 @@ TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoor
 		TArray<FVector2D> SamplePoints;
 		SamplePoints.Reserve(InstanceCount);
 
-		if (bApplyHeuristics)
-		{
-			GenerateClusteredSamples(RandomStream, InstanceCount, TileStart, 64.0f, 2.0f, SamplePoints);
-		}
-		else
-		{
-			for (int32 i = 0; i < InstanceCount; ++i)
-			{
-				SamplePoints.Add(GeneratePoissonSample(RandomStream, TileStart, 64.0f, 2.0f));
-			}
-		}
+                const float MinDistance = FMath::Max(2.0f, TileSize * 0.03125f); // roughly 2m at 64m tiles
+                if (bApplyHeuristics)
+                {
+                        GenerateClusteredSamples(RandomStream, InstanceCount, TileStart, TileSize, MinDistance, SamplePoints);
+                }
+                else
+                {
+                        for (int32 i = 0; i < InstanceCount; ++i)
+                        {
+                                SamplePoints.Add(GeneratePoissonSample(RandomStream, TileStart, TileSize, MinDistance));
+                        }
+                }
 
-		int32 ValidInstances = 0;
-		int32 HeightRejections = 0;
-		int32 SlopeRejections = 0;
+                int32 ValidInstances = 0;
+                int32 HeightRejections = 0;
+                int32 SlopeRejections = 0;
 
-		for (const FVector2D& SamplePoint : SamplePoints)
-		{
-			FVector WorldPos = FVector(SamplePoint, 0.0f);
-			bool bPassesHeightCheck = true;
-			bool bPassesSlopeCheck = true;
+                for (const FVector2D& SamplePoint : SamplePoints)
+                {
+                        FVector WorldPos = FVector(SamplePoint, 0.0f);
+                        bool bPassesHeightCheck = true;
+                        bool bPassesSlopeCheck = true;
 
-			const int32 HeightX = FMath::Clamp(FMath::FloorToInt(SamplePoint.X - TileStart.X), 0, 63);
-			const int32 HeightY = FMath::Clamp(FMath::FloorToInt(SamplePoint.Y - TileStart.Y), 0, 63);
-			const int32 HeightIndex = HeightY * 64 + HeightX;
+                        const int32 HeightX = FMath::Clamp(FMath::FloorToInt((SamplePoint.X - TileStart.X) * InvSampleSpacing), 0, SamplesPerSide - 1);
+                        const int32 HeightY = FMath::Clamp(FMath::FloorToInt((SamplePoint.Y - TileStart.Y) * InvSampleSpacing), 0, SamplesPerSide - 1);
+                        const int32 HeightIndex = HeightY * SamplesPerSide + HeightX;
 
-			const float Height = HeightData[HeightIndex];
-			WorldPos.Z = Height;
+                        const float Height = HeightData[HeightIndex];
+                        WorldPos.Z = Height;
 
-			if (!(Height >= VegRule.MinHeight && Height <= VegRule.MaxHeight))
+                        if (!(Height >= VegRule.MinHeight && Height <= VegRule.MaxHeight))
 			{
 				bPassesHeightCheck = false;
 			}
 
 			if (bPassesHeightCheck)
 			{
-				const float Slope = CalculateSlope(HeightData, HeightX, HeightY, 64);
+                                const float Slope = CalculateSlope(HeightData, HeightX, HeightY, SamplesPerSide);
 				if (Slope > VegRule.SlopeLimit)
 				{
 					bPassesSlopeCheck = false;
@@ -2130,8 +2186,9 @@ TArray<FPOIData> UPCGWorldService::GeneratePOIInstances(FTileCoord TileCoord, co
 	TArray<FPOIData> POIs;
 
 	// Calculate tile world position
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+        FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
 
 	// Initialize seeded random for consistent generation
 	FRandomStream RandomStream(GetTileRandomSeed(TileCoord));
@@ -2584,7 +2641,7 @@ FPCGGraphValidationResult UPCGWorldService::ValidatePCGGraph(const FString& Grap
                 const FTileCoord SampleTile(0, 0);
                 const uint32 TileSeed = GetTileRandomSeed(SampleTile);
 
-                UPCGParamData* ParameterData = Private::CreateTileParameterData(this, DummyMetrics, SampleTile, EBiomeType::None, WorldGenSettings, TileSeed);
+                UPCGParamData* ParameterData = Private::CreateTileParameterData(this, DummyMetrics, SampleTile, EBiomeType::None, WorldGenSettings, TileSeed, 1.0f);
                 UPCGPointData* PointData = Private::CreateTilePointData(this, SampleTile, WorldGenSettings, DummyMetrics);
 
                 if (ParameterData && PointData)
@@ -2884,16 +2941,16 @@ bool UPCGWorldService::AddInstance(FTileCoord TileCoord, const FPCGInstanceData&
 
 bool UPCGWorldService::RemovePOI(FGuid POIId)
 {
-	// Find POI in spawned POIs
-	FPOIData* POIData = SpawnedPOIs.Find(POIId);
-	if (!POIData)
+        // Find POI in spawned POIs
+        FPOIData* POIData = SpawnedPOIs.Find(POIId);
+        if (!POIData)
 	{
 		UE_LOG(LogPCGWorldService, Warning, TEXT("POI %s not found in spawned POIs"), *POIId.ToString());
 		return false;
 	}
 
 	// Get the tile coordinate for persistence logging
-	FTileCoord TileCoord = FTileCoord::FromWorldPosition(POIData->Location, 64.0f);
+        FTileCoord TileCoord = FTileCoord::FromWorldPosition(POIData->Location, WorldGenSettings.TileSizeMeters);
 
 	// Destroy the spawned actor if it exists
 	if (TObjectPtr<AActor>* FoundPtr = SpawnedPOIActors.Find(POIId))
@@ -2915,17 +2972,32 @@ bool UPCGWorldService::RemovePOI(FGuid POIId)
 	// Remove from spawned POIs map
 	SpawnedPOIs.Remove(POIId);
 
-	UE_LOG(LogPCGWorldService, Log, TEXT("Removed POI %s (%s)"), *POIId.ToString(), *POIData->POIName);
-	return true;
+        UE_LOG(LogPCGWorldService, Log, TEXT("Removed POI %s (%s)"), *POIId.ToString(), *POIData->POIName);
+        return true;
+}
+
+void UPCGWorldService::SetHeightfieldService(UHeightfieldService* InHeightfieldService)
+{
+        HeightfieldService = InHeightfieldService;
+
+        if (HeightfieldService)
+        {
+                UE_LOG(LogPCGWorldService, Log, TEXT("Heightfield service bound for terrain projection"));
+        }
+        else
+        {
+                UE_LOG(LogPCGWorldService, Warning,
+                        TEXT("Heightfield service cleared; PCG instances will rely on authored Z values"));
+        }
 }
 
 bool UPCGWorldService::AddPOI(const FPOIData& POIData)
 {
-	// Validate POI ID is properly initialized
-	ensureMsgf(POIData.POIId.IsValid(), TEXT("AddPOI: POIData must have a valid POIId"));
+        // Validate POI ID is properly initialized
+        ensureMsgf(POIData.POIId.IsValid(), TEXT("AddPOI: POIData must have a valid POIId"));
 
 	// Get the tile coordinate for persistence logging
-	FTileCoord TileCoord = FTileCoord::FromWorldPosition(POIData.Location, 64.0f);
+        FTileCoord TileCoord = FTileCoord::FromWorldPosition(POIData.Location, WorldGenSettings.TileSizeMeters);
 
 	// Add to spawned POIs map
 	SpawnedPOIs.Add(POIData.POIId, POIData);
@@ -3206,15 +3278,16 @@ float UPCGWorldService::CalculateSlope(const TArray<float>& HeightData, int32 X,
 }
 FPCGTileMetrics UPCGWorldService::AnalyzeTileMetrics(const TArray<float>& HeightData) const
 {
-	FPCGTileMetrics Metrics;
-	const int32 ExpectedSize = 64 * 64;
-	if (HeightData.Num() != ExpectedSize)
-	{
-		return Metrics;
-	}
+        FPCGTileMetrics Metrics;
+        const float SamplesPerSideFloat = WorldGenSettings.TileSizeMeters / FMath::Max(KINDA_SMALL_NUMBER, WorldGenSettings.SampleSpacingMeters);
+        const int32 GridSize = FMath::Clamp(FMath::RoundToInt(SamplesPerSideFloat), 1, 4096);
+        const int32 ExpectedSize = GridSize * GridSize;
+        if (HeightData.Num() != ExpectedSize)
+        {
+                return Metrics;
+        }
 
-	const int32 GridSize = 64;
-	const float SeaLevel = WorldGenSettings.SeaLevel;
+        const float SeaLevel = WorldGenSettings.SeaLevel;
 
 	float SumHeight = 0.0f;
 	float SumSlope = 0.0f;
@@ -3274,22 +3347,70 @@ FPCGTileMetrics UPCGWorldService::AnalyzeTileMetrics(const TArray<float>& Height
 
 float UPCGWorldService::ComputeEnvironmentScale(const FPCGTileMetrics& TileMetrics, const FPCGVegetationRule& VegRule) const
 {
-	float SlopeFactor = 1.0f;
-	if (VegRule.SlopeLimit > KINDA_SMALL_NUMBER)
-	{
-		SlopeFactor = FMath::Clamp(1.0f - (TileMetrics.AverageSlope / FMath::Max(VegRule.SlopeLimit, 1.0f)), 0.0f, 1.0f);
-	}
+        float SlopeFactor = 1.0f;
+        if (VegRule.SlopeLimit > KINDA_SMALL_NUMBER)
+        {
+                SlopeFactor = FMath::Clamp(1.0f - (TileMetrics.AverageSlope / FMath::Max(VegRule.SlopeLimit, 1.0f)), 0.0f, 1.0f);
+        }
 
-	float WaterFactor = 1.0f;
-	const float WaterFalloff = FMath::Max(10.0f, WorldGenSettings.TileSizeMeters * 0.75f);
-	WaterFactor = FMath::Clamp(1.0f - (TileMetrics.MinAbsWaterDistance / WaterFalloff), 0.2f, 1.0f);
+        float WaterFactor = 1.0f;
+        const float WaterFalloff = FMath::Max(10.0f, WorldGenSettings.TileSizeMeters * 0.75f);
+        WaterFactor = FMath::Clamp(1.0f - (TileMetrics.MinAbsWaterDistance / WaterFalloff), 0.2f, 1.0f);
 
-	if (TileMetrics.WaterCoverageRatio > 0.0f && VegRule.MaxHeight > WorldGenSettings.SeaLevel)
-	{
-		WaterFactor *= 1.0f - TileMetrics.WaterCoverageRatio;
-	}
+        if (TileMetrics.WaterCoverageRatio > 0.0f && VegRule.MaxHeight > WorldGenSettings.SeaLevel)
+        {
+                WaterFactor *= 1.0f - TileMetrics.WaterCoverageRatio;
+        }
 
-	return FMath::Clamp(SlopeFactor * WaterFactor, 0.1f, 1.5f);
+        return FMath::Clamp(SlopeFactor * WaterFactor, 0.1f, 1.5f);
+}
+
+float UPCGWorldService::EstimateWorkUnitsForBiome(EBiomeType BiomeType, const FPCGTileMetrics* TileMetrics) const
+{
+        const FBiomeDefinition* BiomeDef = BiomeDefinitions.Find(BiomeType);
+        if (!BiomeDef)
+        {
+                return 0.0f;
+        }
+
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float TileArea = TileSize * TileSize;
+        const float BiomeWeight = 1.0f;
+
+        float EstimatedUnits = 0.0f;
+        for (const FPCGVegetationRule& VegRule : BiomeDef->VegetationRules)
+        {
+                float Density = VegRule.Density * WorldGenSettings.VegetationDensity * BiomeWeight;
+                if (TileMetrics)
+                {
+                        Density *= ComputeEnvironmentScale(*TileMetrics, VegRule);
+                }
+
+                const float RuleUnits = FMath::Max(0.0f, Density * TileArea / 100.0f);
+                EstimatedUnits += RuleUnits;
+        }
+
+        // POI placement cost is coarse but keeps density scaling responsive when vegetation is sparse
+        EstimatedUnits += static_cast<float>(BiomeDef->POIRules.Num()) * 10.0f;
+
+        return EstimatedUnits;
+}
+
+float UPCGWorldService::ComputeDensityScaleFromWork(float EstimatedWorkUnits) const
+{
+        static constexpr float WorkUnitsPerMs = 500.0f;
+
+        if (EstimatedWorkUnits <= KINDA_SMALL_NUMBER)
+        {
+                return 1.0f;
+        }
+
+        const float TargetMs = FMath::Max(0.1f, WorldGenSettings.PCGTargetMsPerTile);
+        const float LoadMs = EstimatedWorkUnits / WorkUnitsPerMs;
+        const float EffectiveLoad = FMath::Max(LoadMs, 0.1f);
+        const float RawScale = TargetMs / EffectiveLoad;
+
+        return FMath::Clamp(RawScale, 0.5f, 1.2f);
 }
 
 bool UPCGWorldService::CheckPOISpacingRequirements(FVector Location, float MinDistance)
@@ -3316,7 +3437,7 @@ void UPCGWorldService::ApplyDensityLimiting(FPCGGenerationData& GenerationData)
 	}
 
 	// Sort instances by some priority (e.g., distance from tile center, or keep first N instances)
-	FVector TileCenter = GenerationData.TileCoord.ToWorldPosition(64.0f);
+        FVector TileCenter = GenerationData.TileCoord.ToWorldPosition(WorldGenSettings.TileSizeMeters);
 
 	GenerationData.GeneratedInstances.Sort([TileCenter](const FPCGInstanceData& A, const FPCGInstanceData& B)
 		{
@@ -3355,7 +3476,7 @@ void UPCGWorldService::CreateHISMComponentsForTile(FTileCoord TileCoord)
 
 	if (!TileActor)
 	{
-		FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
+                FVector TileWorldPos = TileCoord.ToWorldPosition(WorldGenSettings.TileSizeMeters);
 		FTransform ActorTransform(FRotator::ZeroRotator, TileWorldPos, FVector::OneVector);
 		TileActor = World->SpawnActor<AActor>(AActor::StaticClass(), ActorTransform);
 #if WITH_EDITOR
@@ -3441,7 +3562,7 @@ UHierarchicalInstancedStaticMeshComponent* UPCGWorldService::GetOrCreateHISMComp
 	NewComponent->SetMobility(EComponentMobility::Movable);
 	NewComponent->SetCanEverAffectNavigation(false);
 	NewComponent->SetupAttachment(RootComponent);
-	NewComponent->SetCullDistances(LODDistances[0], LODDistances[2]);
+        NewComponent->SetCullDistances(CullDistances[0], CullDistances[2]);
 	NewComponent->bUseAsOccluder = false; // Vegetation typically shouldnt occlude
 	NewComponent->RegisterComponent();
 
@@ -3482,16 +3603,24 @@ float UPCGWorldService::EstimateMemoryUsage()
 
 bool UPCGWorldService::FindPOILocationStratified(FTileCoord TileCoord, const FPOISpawnRule& POIRule, const TArray<float>& HeightData, FRandomStream& RandomStream, FVector& OutLocation)
 {
-	// Calculate tile bounds
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
+        // Calculate tile bounds
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float InvSampleSpacing = 1.0f / FMath::Max(KINDA_SMALL_NUMBER, WorldGenSettings.SampleSpacingMeters);
+        const int32 SamplesPerSide = FMath::Clamp(FMath::RoundToInt(WorldGenSettings.TileSizeMeters * InvSampleSpacing), 1, 4096);
+        if (HeightData.Num() != SamplesPerSide * SamplesPerSide)
+        {
+                return false;
+        }
 
-	// Use stratified sampling - divide tile into 4x4 grid and sample within each cell
-	const int32 GridSize = 4;
-	const float CellSize = 64.0f / GridSize;
+        FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+        FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
 
-	// Try multiple cells for better distribution
-	TArray<FIntVector2> CellIndices;
+        // Use stratified sampling - divide tile into 4x4 grid and sample within each cell
+        const int32 GridSize = 4;
+        const float CellSize = TileSize / GridSize;
+
+        // Try multiple cells for better distribution
+        TArray<FIntVector2> CellIndices;
 	for (int32 Y = 0; Y < GridSize; Y++)
 	{
 		for (int32 X = 0; X < GridSize; X++)
@@ -3511,17 +3640,18 @@ bool UPCGWorldService::FindPOILocationStratified(FTileCoord TileCoord, const FPO
 	for (const FIntVector2& CellIndex : CellIndices)
 	{
 		// Generate random point within this cell
-		FVector2D CellMin = TileStart + FVector2D(CellIndex.X * CellSize, CellIndex.Y * CellSize);
-		FVector2D RandomOffset = FVector2D(
-			RandomStream.FRandRange(2.0f, CellSize - 2.0f),
-			RandomStream.FRandRange(2.0f, CellSize - 2.0f)
-		);
-		FVector2D SamplePoint = CellMin + RandomOffset;
+                FVector2D CellMin = TileStart + FVector2D(CellIndex.X * CellSize, CellIndex.Y * CellSize);
+                const float Padding = FMath::Min(CellSize * 0.1f, 2.0f);
+                FVector2D RandomOffset = FVector2D(
+                        RandomStream.FRandRange(Padding, CellSize - Padding),
+                        RandomStream.FRandRange(Padding, CellSize - Padding)
+                );
+                FVector2D SamplePoint = CellMin + RandomOffset;
 
-		// Convert to heightfield coordinates
-		int32 HeightX = FMath::Clamp(FMath::FloorToInt(SamplePoint.X - TileStart.X), 0, 63);
-		int32 HeightY = FMath::Clamp(FMath::FloorToInt(SamplePoint.Y - TileStart.Y), 0, 63);
-		int32 HeightIndex = HeightY * 64 + HeightX;
+                // Convert to heightfield coordinates
+                int32 HeightX = FMath::Clamp(FMath::FloorToInt((SamplePoint.X - TileStart.X) * InvSampleSpacing), 0, SamplesPerSide - 1);
+                int32 HeightY = FMath::Clamp(FMath::FloorToInt((SamplePoint.Y - TileStart.Y) * InvSampleSpacing), 0, SamplesPerSide - 1);
+                int32 HeightIndex = HeightY * SamplesPerSide + HeightX;
 
 		if (!HeightData.IsValidIndex(HeightIndex))
 		{
@@ -3530,7 +3660,7 @@ bool UPCGWorldService::FindPOILocationStratified(FTileCoord TileCoord, const FPO
 
 		// Get terrain data at this location
 		float Height = HeightData[HeightIndex];
-		float Slope = CalculateSlope(HeightData, HeightX, HeightY, 64);
+                float Slope = CalculateSlope(HeightData, HeightX, HeightY, SamplesPerSide);
 		FVector TestLocation(SamplePoint.X, SamplePoint.Y, Height);
 
 		// Check slope requirements
@@ -3558,11 +3688,11 @@ bool UPCGWorldService::FindPOILocationStratified(FTileCoord TileCoord, const FPO
 			bool bIsFlatArea = true;
 			float MaxSlopeInArea = 0.0f;
 
-			for (int32 CheckY = FMath::Max(0, HeightY - 1); CheckY <= FMath::Min(63, HeightY + 1); CheckY++)
-			{
-				for (int32 CheckX = FMath::Max(0, HeightX - 1); CheckX <= FMath::Min(63, HeightX + 1); CheckX++)
-				{
-					float LocalSlope = CalculateSlope(HeightData, CheckX, CheckY, 64);
+                        for (int32 CheckY = FMath::Max(0, HeightY - 1); CheckY <= FMath::Min(SamplesPerSide - 1, HeightY + 1); CheckY++)
+                        {
+                                for (int32 CheckX = FMath::Max(0, HeightX - 1); CheckX <= FMath::Min(SamplesPerSide - 1, HeightX + 1); CheckX++)
+                                {
+                                        float LocalSlope = CalculateSlope(HeightData, CheckX, CheckY, SamplesPerSide);
 					MaxSlopeInArea = FMath::Max(MaxSlopeInArea, LocalSlope);
 					if (LocalSlope > POIRule.SlopeLimit * 0.5f) // Stricter slope for flat ground
 					{

--- a/Source/Vibeheim/WorldGen/Private/WorldGenManager.cpp
+++ b/Source/Vibeheim/WorldGen/Private/WorldGenManager.cpp
@@ -141,17 +141,18 @@ bool AWorldGenManager::InitializeWorldGenSystems()
 	ReloadWorldGenAssets();
 
 	// Initialize PCG World Service
-	PCGWorldService = NewObject<UPCGWorldService>(this);
-	if (!PCGWorldService || !PCGWorldService->Initialize(WorldGenSettings->Settings))
-	{
-		UE_LOG(LogWorldGenManager, Error, TEXT("Failed to initialize PCG World Service"));
-		return false;
-	}
-	ReloadWorldGenAssets();
+        PCGWorldService = NewObject<UPCGWorldService>(this);
+        if (!PCGWorldService || !PCGWorldService->Initialize(WorldGenSettings->Settings))
+        {
+                UE_LOG(LogWorldGenManager, Error, TEXT("Failed to initialize PCG World Service"));
+                return false;
+        }
+        PCGWorldService->SetHeightfieldService(HeightfieldService);
+        ReloadWorldGenAssets();
 
 
-	// Initialize POI Service
-	POIService = NewObject<UPOIService>(this);
+        // Initialize POI Service
+        POIService = NewObject<UPOIService>(this);
 	if (!POIService || !POIService->Initialize(WorldGenSettings->Settings))
 	{
 		UE_LOG(LogWorldGenManager, Error, TEXT("Failed to initialize POI Service"));

--- a/Source/Vibeheim/WorldGen/Public/Data/WorldGenTypes.h
+++ b/Source/Vibeheim/WorldGen/Public/Data/WorldGenTypes.h
@@ -19,6 +19,7 @@ class UBlueprint;
 // Forward declare PCG classes (optional dependency)
 class UPCGGraph;
 class UCurveFloat;
+struct FWorldGenConfig;
 
 /**
  * Tile coordinate structure for world partitioning
@@ -39,24 +40,34 @@ struct VIBEHEIM_API FTileCoord
 	FTileCoord(int32 InX, int32 InY) : X(InX), Y(InY) {}
 	FTileCoord(FIntVector2 InCoord) : X(InCoord.X), Y(InCoord.Y) {}
 
-	// Convert world position to tile coordinate
-	static FTileCoord FromWorldPosition(FVector WorldPos, float TileSize = 64.0f)
-	{
-		return FTileCoord(
-			FMath::FloorToInt(WorldPos.X / TileSize),
-			FMath::FloorToInt(WorldPos.Y / TileSize)
-		);
-	}
+        // Convert world position to tile coordinate
+        static FTileCoord FromWorldPosition(FVector WorldPos, float TileSize = 64.0f)
+        {
+                return FTileCoord(
+                        FMath::FloorToInt(WorldPos.X / TileSize),
+                        FMath::FloorToInt(WorldPos.Y / TileSize)
+                );
+        }
 
-	// Convert tile coordinate to world position (center of tile)
-	FVector ToWorldPosition(float TileSize = 64.0f) const
-	{
-		return FVector(
-			(X + 0.5f) * TileSize,
-			(Y + 0.5f) * TileSize,
-			0.0f
-		);
-	}
+        static FTileCoord FromWorldPosition(const FVector& WorldPos, const FWorldGenConfig& Config)
+        {
+                return FromWorldPosition(WorldPos, Config.TileSizeMeters);
+        }
+
+        // Convert tile coordinate to world position (center of tile)
+        FVector ToWorldPosition(float TileSize = 64.0f) const
+        {
+                return FVector(
+                        (X + 0.5f) * TileSize,
+                        (Y + 0.5f) * TileSize,
+                        0.0f
+                );
+        }
+
+        FVector ToWorldPosition(const FWorldGenConfig& Config) const
+        {
+                return ToWorldPosition(Config.TileSizeMeters);
+        }
 
 	// Hash function for use in TMap
 	friend uint32 GetTypeHash(const FTileCoord& Coord);

--- a/Source/Vibeheim/WorldGen/Public/Services/IPCGWorldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/IPCGWorldService.h
@@ -30,11 +30,17 @@ struct VIBEHEIM_API FPCGGenerationData
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
 	int32 TotalInstanceCount = 0;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
-	uint64 InstanceTransformHash = 0;
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
+        uint64 InstanceTransformHash = 0;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
-	float GenerationTimeMs = 0.0f;
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
+        float GenerationTimeMs = 0.0f;
+
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
+        float DensityScale = 1.0f;
+
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
+        float EstimatedWorkUnits = 0.0f;
 };
 
 UINTERFACE(MinimalAPI, Blueprintable)

--- a/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
@@ -19,6 +19,7 @@ class UHierarchicalInstancedStaticMeshComponent;
 class AActor;
 class UPCGGraph;
 class UInstancePersistenceManager;
+class UHeightfieldService;
 #if VHM_PCG_ENABLED
 class UPCGComponent;
 class UPCGParamData;
@@ -86,11 +87,11 @@ public:
 	/**
 	 * Set biome definitions for PCG generation
 	 */
-	UFUNCTION(BlueprintCallable, Category = "PCG")
-	void SetBiomeDefinitions(const TMap<EBiomeType, FBiomeDefinition>& InBiomeDefinitions);
+        UFUNCTION(BlueprintCallable, Category = "PCG")
+        void SetBiomeDefinitions(const TMap<EBiomeType, FBiomeDefinition>& InBiomeDefinitions);
 
-	/**
-	 * Set instance persistence manager for saving/loading modifications
+        /**
+         * Set instance persistence manager for saving/loading modifications
 	 */
 	UFUNCTION(BlueprintCallable, Category = "PCG")
 	void SetPersistenceManager(UInstancePersistenceManager* InPersistenceManager);
@@ -110,18 +111,24 @@ public:
 	/**
 	 * Remove specific POI and persist the change
 	 */
-	UFUNCTION(BlueprintCallable, Category = "PCG")
-	bool RemovePOI(FGuid POIId);
+        UFUNCTION(BlueprintCallable, Category = "PCG")
+        bool RemovePOI(FGuid POIId);
 
-	/**
-	 * Add new POI and persist the change
-	 */
-	UFUNCTION(BlueprintCallable, Category = "PCG")
-	bool AddPOI(const FPOIData& POIData);
+        /**
+         * Add new POI and persist the change
+         */
+        UFUNCTION(BlueprintCallable, Category = "PCG")
+        bool AddPOI(const FPOIData& POIData);
 
-	/**
-	 * Load tile with persistence reconciliation
-	 */
+        /**
+         * Provide the heightfield service used for terrain sampling.
+         */
+        UFUNCTION(BlueprintCallable, Category = "PCG")
+        void SetHeightfieldService(UHeightfieldService* InHeightfieldService);
+
+        /**
+         * Load tile with persistence reconciliation
+         */
         UFUNCTION(BlueprintCallable, Category = "PCG")
         bool LoadTileWithPersistence(FTileCoord TileCoord, EBiomeType BiomeType, const TArray<float>& HeightData);
 
@@ -183,7 +190,7 @@ private:
 	int32 MaxInstancesPerTile;
 
 	UPROPERTY()
-	TArray<float> LODDistances;
+        TArray<float> CullDistances;
 
 	// PCG-related properties (always declared but only used when WITH_PCG is true)
 	UPROPERTY()
@@ -199,6 +206,9 @@ private:
 	// Instance persistence manager
         UPROPERTY()
         TObjectPtr<UInstancePersistenceManager> PersistenceManager;
+
+        UPROPERTY()
+        TObjectPtr<UHeightfieldService> HeightfieldService;
 
 #if VHM_PCG_ENABLED
         TWeakObjectPtr<AActor> PCGAnchorActor;
@@ -247,12 +257,12 @@ private:
 	/**
 	 * Generate vegetation instances for a tile
 	 */
-	TArray<FPCGInstanceData> GenerateVegetationInstances(FTileCoord TileCoord, const FBiomeDefinition& BiomeDef, const TArray<float>& HeightData, const FPCGTileMetrics* TileMetrics = nullptr, bool bUsePCGHeuristics = false);
+        TArray<FPCGInstanceData> GenerateVegetationInstances(FTileCoord TileCoord, const FBiomeDefinition& BiomeDef, const TArray<float>& HeightData, const FPCGTileMetrics* TileMetrics = nullptr, bool bUsePCGHeuristics = false, float DensityScale = 1.0f);
 
 	/**
 	 * Generate vegetation instances for a tile with spawn parameters (forced biome mode support)
 	 */
-	TArray<FPCGInstanceData> GenerateVegetationInstances(FTileCoord TileCoord, const FBiomeDefinition& BiomeDef, const TArray<float>& HeightData, const FPCGSpawnParams& SpawnParams, const FPCGTileMetrics* TileMetrics = nullptr, bool bUsePCGHeuristics = false);
+        TArray<FPCGInstanceData> GenerateVegetationInstances(FTileCoord TileCoord, const FBiomeDefinition& BiomeDef, const TArray<float>& HeightData, const FPCGSpawnParams& SpawnParams, const FPCGTileMetrics* TileMetrics = nullptr, bool bUsePCGHeuristics = false, float DensityScale = 1.0f);
 
 	/**
 	 * Generate POI instances for a tile
@@ -287,7 +297,11 @@ private:
 
 	FPCGTileMetrics AnalyzeTileMetrics(const TArray<float>& HeightData) const;
 
-	float ComputeEnvironmentScale(const FPCGTileMetrics& TileMetrics, const FPCGVegetationRule& VegRule) const;
+        float ComputeEnvironmentScale(const FPCGTileMetrics& TileMetrics, const FPCGVegetationRule& VegRule) const;
+
+        float EstimateWorkUnitsForBiome(EBiomeType BiomeType, const FPCGTileMetrics* TileMetrics) const;
+
+        float ComputeDensityScaleFromWork(float EstimatedWorkUnits) const;
 
 	UPCGGraph* ResolveBiomePCGGraph(EBiomeType BiomeType);
 

--- a/Source/Vibeheim/WorldGen/Public/Services/PCGWorldServiceTypes.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/PCGWorldServiceTypes.h
@@ -33,14 +33,16 @@ namespace VHMPCGAttr
 	inline const FName TileSeed(TEXT("TileSeed")); // Hash(TileX, TileY, BiomeId, GlobalSeed)
 	inline const FName TileX(TEXT("TileX"));
 	inline const FName TileY(TEXT("TileY"));
-	inline const FName TileSize(TEXT("TileSize"));
-	inline const FName BiomeWeight(TEXT("BiomeWeight"));
-	inline const FName StaticMesh(TEXT("StaticMesh"));
-	inline const FName Mesh(TEXT("Mesh"));
-	inline const FName InstanceScale(TEXT("InstanceScale"));
-	inline const FName InstanceRotation(TEXT("InstanceRotation"));
-	inline const FName IsActive(TEXT("IsActive"));
-	inline const FName InstanceId(TEXT("InstanceId"));
+        inline const FName TileSize(TEXT("TileSize"));
+        inline const FName BiomeWeight(TEXT("BiomeWeight"));
+        inline const FName DensityScale(TEXT("DensityScale"));
+        inline const FName StaticMesh(TEXT("StaticMesh"));
+        inline const FName Mesh(TEXT("Mesh"));
+        inline const FName InstanceScale(TEXT("InstanceScale"));
+        inline const FName InstanceRotation(TEXT("InstanceRotation"));
+        inline const FName IsActive(TEXT("IsActive"));
+        inline const FName InstanceId(TEXT("InstanceId"));
+        inline const FName RespectGraphZ(TEXT("RespectGraphZ"));
 }
 
 /** Aggregated tile metrics computed prior to scheduling PCG graphs. */


### PR DESCRIPTION
## Summary
- replace hard-coded 64m assumptions across PCG and heightfield services with `WorldGenSettings.TileSizeMeters`, wiring helpers and metrics through tile analysis
- add density scaling from `PCGTargetMsPerTile`, propagate a `DensityScale` attribute, and document Soft Object Path mesh metadata requirements
- project PCG instances onto the terrain when graphs opt out via `RespectGraphZ`, bind the heightfield service, and add an engine version guard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e565e33acc832aa2a0ad1f99c29907