### PR TITLE
Expose biome weights to PCG graphs and guard headless overrides

### DIFF
--- a/Content/_Assets/Data/PCG/README_PCGContract.md
+++ b/Content/_Assets/Data/PCG/README_PCGContract.md
@@ -1,0 +1,30 @@
+# Runtime PCG Contract
+
+This file captures the expectations between runtime code and designer-authored PCG graphs.
+
+## Canonical inputs
+- **Tile** – Spatial input representing the tile volume. All graphs should consume this pin.
+- **TileParameters** – Parameter data that exposes tile metrics (seed, slope, biome weight, etc.).
+
+> ✅ Keep pin names and tags exactly as shown so runtime scheduling can wire graphs automatically.
+
+## Cookbook: minimal scatter graph
+1. **Input (Tile)** → feed into `Distribute Points in Volume` configured to the tile extents.
+2. **Input (TileParameters)** → use `Get Attribute` nodes to read:
+   - `TileSeed`
+   - `AverageSlope`
+   - `MinWaterDistance`
+   - `TileSize`
+   - `DensityScale`
+   - `BiomeWeight`
+3. Use `TileSeed` for any stochastic node to keep generation deterministic.
+4. Optionally derive per-point data (e.g., via a custom *GetTerrainHeight* node) and filter against slope or water proximity.
+5. Before output, write attributes with `Set Attribute`:
+   - `Mesh` (**Soft Object Path**, never an object pointer)
+   - `InstanceScale` (`Vector`)
+   - `InstanceRotation` (`Rotator`)
+   - `RespectGraphZ` (`bool`, set to `false` if C++ should project onto the terrain)
+6. Emit the result through the **Output → Points** pin.
+
+### Soft reference policy
+Runtime extraction only honours mesh references authored as Soft Object Paths. Pointer types (`UStaticMesh*`, `Object`) do not participate in streaming or blends.

--- a/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
@@ -38,6 +38,7 @@
 #include "HAL/FileManager.h"
 #include "Trace/Trace.inl"
 #include "Services/HeightfieldService.h"
+#include "Services/BiomeService.h"
 
 UE_DEFINE_LOG_CATEGORY(LogPCGWorldService);
 
@@ -451,7 +452,7 @@ namespace PCGWorldService::Private
 
 static UPCGParamData* CreateTileParameterData(UObject* Outer, const FPCGTileMetrics& TileMetrics,
                 FTileCoord TileCoord, EBiomeType BiomeType, const FWorldGenConfig& WorldGenSettings, uint32 TileSeed,
-                float DensityScale);
+                float DensityScale, float BiomeWeight);
 
         static UPCGPointData* CreateTilePointData(UObject* Outer, FTileCoord TileCoord, const FWorldGenConfig& WorldGenSettings,
                 const FPCGTileMetrics& TileMetrics);
@@ -1005,7 +1006,7 @@ void UPCGWorldService::HandleWorldCleanup(UWorld* World, bool bSessionEnded, boo
 #if VHM_PCG_ENABLED
 UPCGParamData* PCGWorldService::Private::CreateTileParameterData(UObject* Outer,
         const FPCGTileMetrics& TileMetrics, FTileCoord TileCoord, EBiomeType BiomeType,
-        const FWorldGenConfig& WorldGenSettings, uint32 TileSeed, float DensityScale)
+        const FWorldGenConfig& WorldGenSettings, uint32 TileSeed, float DensityScale, float BiomeWeight)
 {
         UPCGParamData* ParamData = NewObject<UPCGParamData>(Outer ? Outer : GetTransientPackage(), NAME_None, RF_Transient);
         if (!ensureMsgf(ParamData, TEXT("Failed to allocate tile parameter data for (%d, %d)"), TileCoord.X, TileCoord.Y))
@@ -1058,7 +1059,7 @@ UPCGParamData* PCGWorldService::Private::CreateTileParameterData(UObject* Outer,
         EnsureAndSetAttribute(VHMPCGAttr::TileX, TileCoord.X, false);
         EnsureAndSetAttribute(VHMPCGAttr::TileY, TileCoord.Y, false);
         EnsureAndSetAttribute(VHMPCGAttr::TileSize, WorldGenSettings.TileSizeMeters, true);
-        EnsureAndSetAttribute(VHMPCGAttr::BiomeWeight, 1.0f, true);
+        EnsureAndSetAttribute(VHMPCGAttr::BiomeWeight, BiomeWeight, true);
         EnsureAndSetAttribute(VHMPCGAttr::DensityScale, DensityScale, true);
 
         return ParamData;
@@ -1476,6 +1477,7 @@ bool UPCGWorldService::Initialize(const FWorldGenConfig& Settings)
 {
         WorldGenSettings = Settings;
         MaxInstancesPerTile = Settings.MaxHISMInstances;
+        bAllowHeadlessLogicalInstances = Settings.bAllowHeadlessLogicalInstances;
         InitializeDefaultBiomes();
 
 #if WITH_AUTOMATION_TESTS && VHM_PCG_ENABLED
@@ -1494,6 +1496,12 @@ bool UPCGWorldService::Initialize(const FWorldGenConfig& Settings)
         {
                 UE_LOG(LogPCGWorldService, Warning,
                         TEXT("Headless mode: PCG running without UWorld; HISM updates will be skipped."));
+
+                if (!bAllowHeadlessLogicalInstances)
+                {
+                        UE_LOG(LogPCGWorldService, Warning,
+                                TEXT("Headless logical instances disabled via config; runtime will avoid force-spawning."));
+                }
         }
 
         bDedicatedServer = IsRunningDedicatedServer();
@@ -1769,8 +1777,9 @@ FPCGGenerationData UPCGWorldService::GeneratePCGContent(FTileCoord TileCoord, EB
     GenerationData.DensityScale = DensityScale;
 
     const uint32 TileSeed = GetTileRandomSeed(TileCoord);
+    const float BiomeBlendWeight = ResolveBiomeBlendWeight(TileCoord, BiomeType, EffectiveMetrics);
     UObject* DataOuter = AnchorActor ? static_cast<UObject*>(AnchorActor) : static_cast<UObject*>(this);
-    UPCGParamData* ParameterData = Private::CreateTileParameterData(DataOuter, EffectiveMetrics ? *EffectiveMetrics : FPCGTileMetrics(), TileCoord, BiomeType, WorldGenSettings, TileSeed, DensityScale);
+    UPCGParamData* ParameterData = Private::CreateTileParameterData(DataOuter, EffectiveMetrics ? *EffectiveMetrics : FPCGTileMetrics(), TileCoord, BiomeType, WorldGenSettings, TileSeed, DensityScale, BiomeBlendWeight);
     UPCGPointData* TilePointData = Private::CreateTilePointData(DataOuter, TileCoord, WorldGenSettings, EffectiveMetrics ? *EffectiveMetrics : FPCGTileMetrics());
 
     FAttributeValidationResult Validation = ValidateInputAttributes(ParameterData, TilePointData);
@@ -1955,12 +1964,15 @@ FPCGGenerationData UPCGWorldService::GenerateFallbackContent(FTileCoord TileCoor
 		EffectiveMetrics = &LocalMetrics;
 	}
 
-	FPCGSpawnParams SpawnParams;
-	if (bHeadless)
-	{
-		SpawnParams.bForceBiome = true;
-		SpawnParams.BiomeOverride = BiomeType;
-	}
+        FPCGSpawnParams SpawnParams;
+        const float BiomeBlendWeight = ResolveBiomeBlendWeight(TileCoord, BiomeType, EffectiveMetrics);
+        SpawnParams.BiomeWeightScale = BiomeBlendWeight;
+
+        if (bHeadless && bAllowHeadlessLogicalInstances)
+        {
+                SpawnParams.bForceBiome = true;
+                SpawnParams.BiomeOverride = BiomeType;
+        }
 
 	if (EffectiveMetrics)
 	{
@@ -1968,10 +1980,9 @@ FPCGGenerationData UPCGWorldService::GenerateFallbackContent(FTileCoord TileCoor
 		const float WaterFalloff = FMath::Max(10.0f, WorldGenSettings.TileSizeMeters * 0.75f);
 		const float WaterFactor = FMath::Clamp(1.0f - (EffectiveMetrics->MinAbsWaterDistance / WaterFalloff), 0.2f, 1.0f);
 
-		SpawnParams.SlopeResponse = SlopeFactor;
-		SpawnParams.WaterResponse = WaterFactor;
-		SpawnParams.BiomeWeightScale = SlopeFactor * WaterFactor;
-	}
+                SpawnParams.SlopeResponse = SlopeFactor;
+                SpawnParams.WaterResponse = WaterFactor;
+        }
 
 	if (bUsePCGHeuristics)
 	{
@@ -2057,10 +2068,10 @@ TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoor
                 const int32 MaxInstancesForThisRule = FMath::Max(1, MaxInstancesPerTile / FMath::Max(1, BiomeDef.VegetationRules.Num()));
                 int32 InstanceCount = FMath::Min(BaseInstanceCount, MaxInstancesForThisRule);
 
-                if (bHeadless && SpawnParams.bForceBiome)
-		{
-			InstanceCount = FMath::Max(InstanceCount, 1);
-		}
+                if (bHeadless && bAllowHeadlessLogicalInstances && SpawnParams.bForceBiome)
+                {
+                        InstanceCount = FMath::Max(InstanceCount, 1);
+                }
 
 		UE_LOG(LogPCGWorldService, VeryVerbose, TEXT("Vegetation rule %s: baseDensity=%.3f baseCount=%d clamped=%d"),
 			VegRule.VegetationMesh.IsNull() ? TEXT("NULL_MESH") : *VegRule.VegetationMesh.GetAssetName(), BaseDensity, BaseInstanceCount, InstanceCount);
@@ -2117,11 +2128,11 @@ TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoor
 				}
 			}
 
-			if (SpawnParams.bForceBiome && bHeadless)
-			{
-				bPassesHeightCheck = true;
-				bPassesSlopeCheck = true;
-			}
+                        if (SpawnParams.bForceBiome && bHeadless && bAllowHeadlessLogicalInstances)
+                        {
+                                bPassesHeightCheck = true;
+                                bPassesSlopeCheck = true;
+                        }
 
 			if (!bPassesHeightCheck)
 			{
@@ -2140,7 +2151,7 @@ TArray<FPCGInstanceData> UPCGWorldService::GenerateVegetationInstances(FTileCoor
 			InstanceData.Rotation = FRotator(0.0f, RandomStream.FRandRange(0.0f, 360.0f), 0.0f);
 			InstanceData.Scale = FVector(RandomStream.FRandRange(VegRule.MinScale, VegRule.MaxScale));
 
-			if (bHeadless && VegRule.VegetationMesh.IsNull())
+                        if (bHeadless && bAllowHeadlessLogicalInstances && VegRule.VegetationMesh.IsNull())
 			{
 				InstanceData.Mesh = TSoftObjectPtr<UStaticMesh>();
 			}
@@ -2641,7 +2652,7 @@ FPCGGraphValidationResult UPCGWorldService::ValidatePCGGraph(const FString& Grap
                 const FTileCoord SampleTile(0, 0);
                 const uint32 TileSeed = GetTileRandomSeed(SampleTile);
 
-                UPCGParamData* ParameterData = Private::CreateTileParameterData(this, DummyMetrics, SampleTile, EBiomeType::None, WorldGenSettings, TileSeed, 1.0f);
+                UPCGParamData* ParameterData = Private::CreateTileParameterData(this, DummyMetrics, SampleTile, EBiomeType::None, WorldGenSettings, TileSeed, 1.0f, 1.0f);
                 UPCGPointData* PointData = Private::CreateTilePointData(this, SampleTile, WorldGenSettings, DummyMetrics);
 
                 if (ParameterData && PointData)
@@ -2989,6 +3000,72 @@ void UPCGWorldService::SetHeightfieldService(UHeightfieldService* InHeightfieldS
                 UE_LOG(LogPCGWorldService, Warning,
                         TEXT("Heightfield service cleared; PCG instances will rely on authored Z values"));
         }
+}
+
+void UPCGWorldService::SetBiomeService(UBiomeService* InBiomeService)
+{
+        BiomeService = InBiomeService;
+
+        if (BiomeService)
+        {
+                UE_LOG(LogPCGWorldService, Log, TEXT("Biome service bound for blend weights"));
+        }
+        else
+        {
+                UE_LOG(LogPCGWorldService, Warning,
+                        TEXT("Biome service cleared; biome weights will default to 1.0"));
+        }
+}
+
+float UPCGWorldService::ResolveBiomeBlendWeight(FTileCoord TileCoord, EBiomeType BiomeType,
+        const FPCGTileMetrics* TileMetrics) const
+{
+        if (!BiomeService)
+        {
+                return 1.0f;
+        }
+
+        const FVector TileCenter = TileCoord.ToWorldPosition(WorldGenSettings.TileSizeMeters);
+        const FVector2D TileCenter2D(TileCenter.X, TileCenter.Y);
+
+        float Altitude = WorldGenSettings.SeaLevel;
+        if (TileMetrics)
+        {
+                Altitude = TileMetrics->AverageHeight;
+        }
+        else if (HeightfieldService)
+        {
+                Altitude = HeightfieldService->GetHeightAtLocation(TileCenter2D);
+        }
+
+        const FBiomeResult BiomeResult = BiomeService->DetermineBiome(TileCenter2D, Altitude);
+
+        EBiomeType QueryBiome = BiomeType;
+        if (QueryBiome == EBiomeType::None && BiomeResult.PrimaryBiome != EBiomeType::None)
+        {
+                QueryBiome = BiomeResult.PrimaryBiome;
+        }
+
+        float Weight = 1.0f;
+        if (const float* RequestedWeight = BiomeResult.BiomeWeights.Find(QueryBiome))
+        {
+                Weight = *RequestedWeight;
+        }
+        else if (const float* PrimaryWeight = BiomeResult.BiomeWeights.Find(BiomeResult.PrimaryBiome))
+        {
+                Weight = *PrimaryWeight;
+        }
+        else if (BiomeResult.BiomeWeights.Num() > 0)
+        {
+                float MaxWeight = 0.0f;
+                for (const TPair<EBiomeType, float>& Pair : BiomeResult.BiomeWeights)
+                {
+                        MaxWeight = FMath::Max(MaxWeight, Pair.Value);
+                }
+                Weight = MaxWeight;
+        }
+
+        return FMath::Clamp(Weight, 0.0f, 1.0f);
 }
 
 bool UPCGWorldService::AddPOI(const FPOIData& POIData)

--- a/Source/Vibeheim/WorldGen/Private/Tests/ClimateSystemTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/ClimateSystemTest.cpp
@@ -165,9 +165,10 @@ bool FIntegratedSystemTest::RunTest(const FString& Parameters)
 	ClimateSystem->Initialize(ClimateSettings, Settings->Settings.Seed);
 	HeightfieldService->Initialize(Settings->Settings);
 	HeightfieldService->SetNoiseSystem(NoiseSystem);
-	HeightfieldService->SetClimateSystem(ClimateSystem);
-	BiomeService->Initialize(ClimateSystem, Settings->Settings);
-	PCGService->Initialize(Settings->Settings);
+        HeightfieldService->SetClimateSystem(ClimateSystem);
+        BiomeService->Initialize(ClimateSystem, Settings->Settings);
+        PCGService->Initialize(Settings->Settings);
+        PCGService->SetBiomeService(BiomeService);
 	
 	// Generate data for a test tile
 	FTileCoord TestTile(1, 1);

--- a/Source/Vibeheim/WorldGen/Private/Tests/WorldGenIntegrationTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/WorldGenIntegrationTest.cpp
@@ -986,10 +986,11 @@ bool UWorldGenIntegrationTest::InitializeServices()
 		{
 			// Initialize PCGWorldService with dependencies
 			bool bPCGInitialized = PCGService->Initialize(WorldGenSettings->Settings);
-			if (bPCGInitialized)
-			{
-				PCGService->SetBiomeDefinitions(BiomeService->GetBiomeDefinitions());
-			}
+                        if (bPCGInitialized)
+                        {
+                                PCGService->SetBiomeDefinitions(BiomeService->GetBiomeDefinitions());
+                                PCGService->SetBiomeService(BiomeService);
+                        }
 			
 			if (bPCGInitialized)
 			{

--- a/Source/Vibeheim/WorldGen/Private/WorldGenManager.cpp
+++ b/Source/Vibeheim/WorldGen/Private/WorldGenManager.cpp
@@ -148,6 +148,7 @@ bool AWorldGenManager::InitializeWorldGenSystems()
                 return false;
         }
         PCGWorldService->SetHeightfieldService(HeightfieldService);
+        PCGWorldService->SetBiomeService(BiomeService);
         ReloadWorldGenAssets();
 
 

--- a/Source/Vibeheim/WorldGen/Private/WorldGenSettings.cpp
+++ b/Source/Vibeheim/WorldGen/Private/WorldGenSettings.cpp
@@ -131,6 +131,7 @@ bool UWorldGenSettings::ApplyFromAssets(const UWorldGenSettingsAsset* SettingsAs
         Settings.bEnableRivers = SettingsAsset->CoreSettings.bEnableRivers;
         Settings.bEnableRings = SettingsAsset->CoreSettings.bEnableRings;
         Settings.bEnablePCGGraphs = SettingsAsset->CoreSettings.bEnablePCGGraphs;
+        Settings.bAllowHeadlessLogicalInstances = SettingsAsset->CoreSettings.bAllowHeadlessLogicalInstances;
 
         MacroWorldConfig = SettingsAsset->MacroWorld;
         StreamingBudgetsConfig = SettingsAsset->StreamingBudgets;
@@ -259,10 +260,15 @@ bool UWorldGenSettings::ParseJSONObject(const TSharedPtr<FJsonObject>& JsonObjec
 		Settings.POIDensity = static_cast<float>(JsonObject->GetNumberField(TEXT("POIDensity")));
 	}
 	
-	if (JsonObject->HasField(TEXT("MaxHISMInstances")))
-	{
-		Settings.MaxHISMInstances = static_cast<int32>(JsonObject->GetNumberField(TEXT("MaxHISMInstances")));
-	}
+        if (JsonObject->HasField(TEXT("MaxHISMInstances")))
+        {
+                Settings.MaxHISMInstances = static_cast<int32>(JsonObject->GetNumberField(TEXT("MaxHISMInstances")));
+        }
+
+        if (JsonObject->HasField(TEXT("bAllowHeadlessLogicalInstances")))
+        {
+                Settings.bAllowHeadlessLogicalInstances = JsonObject->GetBoolField(TEXT("bAllowHeadlessLogicalInstances"));
+        }
 
 	// Parse biome settings
 	if (JsonObject->HasField(TEXT("BiomeScale")))
@@ -336,6 +342,10 @@ bool UWorldGenSettings::ParseJSONObject(const TSharedPtr<FJsonObject>& JsonObjec
             if (Features->HasField(TEXT("EnablePCGGraphs")))
             {
                 Settings.bEnablePCGGraphs = Features->GetBoolField(TEXT("EnablePCGGraphs"));
+            }
+            if (Features->HasField(TEXT("AllowHeadlessLogicalInstances")))
+            {
+                Settings.bAllowHeadlessLogicalInstances = Features->GetBoolField(TEXT("AllowHeadlessLogicalInstances"));
             }
         }
     }
@@ -454,12 +464,14 @@ TSharedPtr<FJsonObject> UWorldGenSettings::CreateJSONObject() const
     JsonObject->SetBoolField(TEXT("bEnableRivers"), Settings.bEnableRivers);
     JsonObject->SetBoolField(TEXT("bEnableRings"), Settings.bEnableRings);
     JsonObject->SetBoolField(TEXT("bEnablePCGGraphs"), Settings.bEnablePCGGraphs);
+    JsonObject->SetBoolField(TEXT("bAllowHeadlessLogicalInstances"), Settings.bAllowHeadlessLogicalInstances);
 
     TSharedPtr<FJsonObject> Features = MakeShareable(new FJsonObject);
     Features->SetBoolField(TEXT("EnableWater"), Settings.bEnableWater);
     Features->SetBoolField(TEXT("EnableRivers"), Settings.bEnableRivers);
     Features->SetBoolField(TEXT("EnableRings"), Settings.bEnableRings);
     Features->SetBoolField(TEXT("EnablePCGGraphs"), Settings.bEnablePCGGraphs);
+    Features->SetBoolField(TEXT("AllowHeadlessLogicalInstances"), Settings.bAllowHeadlessLogicalInstances);
     JsonObject->SetObjectField(TEXT("Features"), Features);
 
 	// VHM settings (nested object)

--- a/Source/Vibeheim/WorldGen/Public/Data/WorldGenTypes.h
+++ b/Source/Vibeheim/WorldGen/Public/Data/WorldGenTypes.h
@@ -184,6 +184,10 @@ struct VIBEHEIM_API FWorldGenConfig
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
     int32 MaxHISMInstances = 10000;
 
+    /** When true, headless environments still spawn logical instances for testing. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG")
+    bool bAllowHeadlessLogicalInstances = true;
+
     /** Enables runtime frustum culling for the PCG scheduler. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PCG|Scheduler", meta = (DisplayName = "Enable Frustum Culling"))
     bool bEnableFrustumCulling = true;

--- a/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
@@ -20,6 +20,7 @@ class AActor;
 class UPCGGraph;
 class UInstancePersistenceManager;
 class UHeightfieldService;
+class UBiomeService;
 #if VHM_PCG_ENABLED
 class UPCGComponent;
 class UPCGParamData;
@@ -126,6 +127,10 @@ public:
         UFUNCTION(BlueprintCallable, Category = "PCG")
         void SetHeightfieldService(UHeightfieldService* InHeightfieldService);
 
+        /** Provide the biome service so tile weights can be propagated to PCG graphs. */
+        UFUNCTION(BlueprintCallable, Category = "PCG")
+        void SetBiomeService(UBiomeService* InBiomeService);
+
         /**
          * Load tile with persistence reconciliation
          */
@@ -193,8 +198,8 @@ private:
         TArray<float> CullDistances;
 
 	// PCG-related properties (always declared but only used when WITH_PCG is true)
-	UPROPERTY()
-	TObjectPtr<UObject> CurrentPCGGraph; // UPCGGraph* when WITH_PCG is available
+        UPROPERTY()
+        TObjectPtr<UObject> CurrentPCGGraph; // UPCGGraph* when WITH_PCG is available
 
         UPROPERTY()
 #if VHM_PCG_ENABLED
@@ -209,6 +214,12 @@ private:
 
         UPROPERTY()
         TObjectPtr<UHeightfieldService> HeightfieldService;
+
+        UPROPERTY()
+        TObjectPtr<UBiomeService> BiomeService;
+
+        UPROPERTY()
+        bool bAllowHeadlessLogicalInstances = true;
 
 #if VHM_PCG_ENABLED
         TWeakObjectPtr<AActor> PCGAnchorActor;
@@ -344,6 +355,9 @@ private:
          * Apply terrain modification stamp for POI placement
          */
         void ApplyPOITerrainStamp(FVector Location, float Radius);
+
+        /** Resolve the blend weight for the requested biome/tile combination. */
+        float ResolveBiomeBlendWeight(FTileCoord TileCoord, EBiomeType BiomeType, const FPCGTileMetrics* TileMetrics) const;
 
 #if VHM_PCG_ENABLED
         void RegisterTelemetry(FPCGTaskId TaskId, EBiomeType BiomeType, const UPCGGraph& Graph, const FTileCoord& TileCoord);


### PR DESCRIPTION
## Summary
- document the canonical Tile and TileParameters inputs and provide a cookbook for designers
- pull biome blend weights from the biome service into PCG parameter data and fallback spawning
- add a headless logical-instance toggle to worldgen config and wire the biome service into the PCG world service

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e58a1f9038832a86ac26eb6005aeb4