### PR TITLE
Adjust world sampling and add terrain height PCG node

### DIFF
--- a/Source/Vibeheim/WorldGen/Private/PCG/VibeheimPCGGetTerrainHeight.cpp
+++ b/Source/Vibeheim/WorldGen/Private/PCG/VibeheimPCGGetTerrainHeight.cpp
@@ -1,0 +1,180 @@
+#include "PCG/VibeheimPCGGetTerrainHeight.h"
+
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "Metadata/PCGMetadata.h"
+#include "Metadata/PCGMetadataAttribute.h"
+#include "PCGContext.h"
+#include "Data/PCGPointData.h"
+#include "WorldGenManager.h"
+#include "Services/HeightfieldService.h"
+
+UVibeheimPCGGetTerrainHeightSettings::UVibeheimPCGGetTerrainHeightSettings()
+{
+}
+
+TArray<FPCGPinProperties> UVibeheimPCGGetTerrainHeightSettings::InputPinProperties() const
+{
+        TArray<FPCGPinProperties> Pins;
+        Pins.Emplace(FName(TEXT("In")), EPCGDataType::Point, true);
+        return Pins;
+}
+
+TArray<FPCGPinProperties> UVibeheimPCGGetTerrainHeightSettings::OutputPinProperties() const
+{
+        TArray<FPCGPinProperties> Pins;
+        Pins.Emplace(FName(TEXT("Out")), EPCGDataType::Point, true, true);
+        return Pins;
+}
+
+FName UVibeheimPCGGetTerrainHeightSettings::GetDefaultNodeName() const
+{
+        return FName(TEXT("GetTerrainHeight"));
+}
+
+FText UVibeheimPCGGetTerrainHeightSettings::GetDefaultNodeTitle() const
+{
+        return NSLOCTEXT("VibeheimPCG", "GetTerrainHeightNodeTitle", "Get Terrain Height");
+}
+
+#if WITH_EDITOR
+FText UVibeheimPCGGetTerrainHeightSettings::GetNodeTooltipText() const
+{
+        return NSLOCTEXT("VibeheimPCG", "GetTerrainHeightTooltip",
+                "Samples the Vibeheim heightfield to annotate points with TerrainHeight/TerrainSlope metadata.");
+}
+#endif
+
+FPCGElementPtr UVibeheimPCGGetTerrainHeightSettings::CreateElement() const
+{
+        return MakeShared<FPCGVibeheimGetTerrainHeightElement>();
+}
+
+static UHeightfieldService* ResolveHeightfieldService(UWorld* World)
+{
+        if (!World)
+        {
+                return nullptr;
+        }
+
+        for (TActorIterator<AWorldGenManager> It(World); It; ++It)
+        {
+                if (AWorldGenManager* Manager = *It)
+                {
+                        return Manager->GetHeightfieldService();
+                }
+        }
+
+        return nullptr;
+}
+
+bool FPCGVibeheimGetTerrainHeightElement::ExecuteInternal(FPCGContext* Context) const
+{
+        check(Context);
+
+        const UVibeheimPCGGetTerrainHeightSettings* Settings = Cast<UVibeheimPCGGetTerrainHeightSettings>(Context->GetSettings());
+        if (!Settings)
+        {
+                return true;
+        }
+
+        UWorld* World = Context->GetWorld();
+        UHeightfieldService* HeightfieldService = ResolveHeightfieldService(World);
+
+        if (!HeightfieldService)
+        {
+                UE_LOG(LogTemp, Warning, TEXT("GetTerrainHeight: Heightfield service unavailable; passing through input points."));
+        }
+
+        const TArray<FPCGTaggedData>& Inputs = Context->InputData.GetInputs();
+        for (const FPCGTaggedData& Input : Inputs)
+        {
+                const UPCGPointData* InPointData = Cast<UPCGPointData>(Input.Data);
+                if (!InPointData)
+                {
+                        FPCGTaggedData& Passthrough = Context->OutputData.TaggedData.Add_GetRef(Input);
+                        Passthrough.Data = Input.Data;
+                        continue;
+                }
+
+                UPCGPointData* OutPointData = DuplicateObject<UPCGPointData>(InPointData, InPointData->GetOuter());
+                if (!OutPointData)
+                {
+                        continue;
+                }
+
+                TArray<FPCGPoint>& Points = OutPointData->GetMutablePoints();
+                UPCGMetadata* Metadata = OutPointData->MutableMetadata();
+
+                FPCGMetadataAttribute<float>* HeightAttr = nullptr;
+                FPCGMetadataAttribute<float>* SlopeAttr = nullptr;
+
+                if (Metadata)
+                {
+                        if (!Settings->HeightAttribute.IsNone())
+                        {
+                                HeightAttr = Metadata->GetMutableTypedAttribute<float>(Settings->HeightAttribute);
+                                if (!HeightAttr)
+                                {
+                                        HeightAttr = Metadata->CreateAttribute<float>(Settings->HeightAttribute, 0.0f, true, true);
+                                }
+                        }
+
+                        if (!Settings->SlopeAttribute.IsNone())
+                        {
+                                SlopeAttr = Metadata->GetMutableTypedAttribute<float>(Settings->SlopeAttribute);
+                                if (!SlopeAttr)
+                                {
+                                        SlopeAttr = Metadata->CreateAttribute<float>(Settings->SlopeAttribute, 0.0f, true, true);
+                                }
+                        }
+                }
+
+                for (FPCGPoint& Point : Points)
+                {
+                        const FVector Location = Point.Transform.GetLocation();
+                        const FVector2D WorldXY(Location.X, Location.Y);
+
+                        float HeightSample = Location.Z;
+                        float SlopeSample = 0.0f;
+
+                        if (HeightfieldService)
+                        {
+                                const float SampledHeight = HeightfieldService->SampleHeightWorldXY(WorldXY);
+                                if (FMath::IsFinite(SampledHeight))
+                                {
+                                        HeightSample = SampledHeight;
+                                }
+
+                                const float SampledSlope = HeightfieldService->GetSlopeAtLocation(WorldXY);
+                                if (FMath::IsFinite(SampledSlope))
+                                {
+                                        SlopeSample = SampledSlope;
+                                }
+                        }
+
+                        if (HeightAttr && Point.MetadataEntry != PCGInvalidEntryKey)
+                        {
+                                HeightAttr->SetValue(Point.MetadataEntry, HeightSample);
+                        }
+
+                        if (SlopeAttr && Point.MetadataEntry != PCGInvalidEntryKey)
+                        {
+                                SlopeAttr->SetValue(Point.MetadataEntry, SlopeSample);
+                        }
+
+                        if (Settings->bProjectPointZ && HeightfieldService && FMath::IsFinite(HeightSample))
+                        {
+                                FVector ProjectedLocation = Location;
+                                ProjectedLocation.Z = HeightSample;
+                                Point.Transform.SetLocation(ProjectedLocation);
+                        }
+                }
+
+                FPCGTaggedData& Output = Context->OutputData.TaggedData.Add_GetRef();
+                Output = Input;
+                Output.Data = OutPointData;
+        }
+
+        return true;
+}

--- a/Source/Vibeheim/WorldGen/Private/Services/BiomeService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/BiomeService.cpp
@@ -361,49 +361,82 @@ FBiomeResult UBiomeService::ApplyBiomeBlending(const TMap<EBiomeType, float>& Bi
 
 TArray<FBiomeResult> UBiomeService::GenerateTileBiomeData(FTileCoord TileCoord, const TArray<float>& HeightData) const
 {
-	TArray<FBiomeResult> BiomeResults;
-	
-	// Calculate tile world position
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f);
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f);
-	
-	// Generate biome data for each sample in the tile (64x64 samples)
-	const int32 SamplesPerTile = 64;
-	BiomeResults.Reserve(SamplesPerTile * SamplesPerTile);
-	
-	for (int32 Y = 0; Y < SamplesPerTile; Y++)
-	{
-		for (int32 X = 0; X < SamplesPerTile; X++)
-		{
-			// Calculate world position for this sample
-			FVector2D SampleWorldPos = TileStart + FVector2D(X, Y);
-			
-			// Get height for this sample
-			float SampleHeight = 0.0f;
-			if (HeightData.IsValidIndex(Y * SamplesPerTile + X))
-			{
-				SampleHeight = HeightData[Y * SamplesPerTile + X];
-			}
-			
-			// Determine biome
-			FBiomeResult BiomeResult = DetermineBiome(SampleWorldPos, SampleHeight);
-			BiomeResults.Add(BiomeResult);
-		}
-	}
-	
-	return BiomeResults;
+TArray<FBiomeResult> BiomeResults;
+
+const float TileSize = WorldGenSettings.TileSizeMeters;
+const FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+const FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
+
+int32 SamplesPerTile = 0;
+if (HeightData.Num() > 0)
+{
+const float Root = FMath::Sqrt(static_cast<float>(HeightData.Num()));
+const int32 RoundedRoot = FMath::RoundToInt(Root);
+if (RoundedRoot > 0 && RoundedRoot * RoundedRoot == HeightData.Num())
+{
+SamplesPerTile = RoundedRoot;
+}
+}
+
+if (SamplesPerTile <= 0)
+{
+const float SampleSpacing = FMath::Max(WorldGenSettings.SampleSpacingMeters, KINDA_SMALL_NUMBER);
+SamplesPerTile = FMath::Clamp(FMath::RoundToInt(TileSize / SampleSpacing), 1, 4096);
+}
+
+const float EffectiveSpacing = SamplesPerTile > 0 ? TileSize / SamplesPerTile : WorldGenSettings.SampleSpacingMeters;
+BiomeResults.Reserve(SamplesPerTile * SamplesPerTile);
+
+for (int32 Y = 0; Y < SamplesPerTile; Y++)
+{
+for (int32 X = 0; X < SamplesPerTile; X++)
+{
+const FVector2D SampleWorldPos = TileStart + FVector2D(X * EffectiveSpacing, Y * EffectiveSpacing);
+
+float SampleHeight = 0.0f;
+if (HeightData.IsValidIndex(Y * SamplesPerTile + X))
+{
+SampleHeight = HeightData[Y * SamplesPerTile + X];
+}
+
+const FBiomeResult BiomeResult = DetermineBiome(SampleWorldPos, SampleHeight);
+BiomeResults.Add(BiomeResult);
+}
+}
+
+return BiomeResults;
 }
 
 bool UBiomeService::ExportBiomePNG(FTileCoord TileCoord, const TArray<float>& HeightData, const FString& OutputPath) const
 {
-	// Generate biome data for the tile
-	TArray<FBiomeResult> BiomeData = GenerateTileBiomeData(TileCoord, HeightData);
-	
-	if (BiomeData.Num() != 64 * 64)
-	{
-		UE_LOG(LogBiomeService, Error, TEXT("Invalid biome data size for tile export"));
-		return false;
-	}
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        int32 SamplesPerTile = 0;
+        if (HeightData.Num() > 0)
+        {
+                const float Root = FMath::Sqrt(static_cast<float>(HeightData.Num()));
+                const int32 RoundedRoot = FMath::RoundToInt(Root);
+                if (RoundedRoot > 0 && RoundedRoot * RoundedRoot == HeightData.Num())
+                {
+                        SamplesPerTile = RoundedRoot;
+                }
+        }
+
+        if (SamplesPerTile <= 0)
+        {
+                const float SampleSpacing = FMath::Max(WorldGenSettings.SampleSpacingMeters, KINDA_SMALL_NUMBER);
+                SamplesPerTile = FMath::Clamp(FMath::RoundToInt(TileSize / SampleSpacing), 1, 4096);
+        }
+
+        const int32 ExpectedSampleCount = SamplesPerTile * SamplesPerTile;
+
+        // Generate biome data for the tile
+        TArray<FBiomeResult> BiomeData = GenerateTileBiomeData(TileCoord, HeightData);
+
+        if (BiomeData.Num() != ExpectedSampleCount)
+        {
+                UE_LOG(LogBiomeService, Error, TEXT("Invalid biome data size for tile export"));
+                return false;
+        }
 	
 	// Create output directory
 	FString FullOutputPath = FPaths::ProjectDir() / OutputPath;
@@ -411,7 +444,7 @@ bool UBiomeService::ExportBiomePNG(FTileCoord TileCoord, const TArray<float>& He
 	
 	// Export biome map
 	TArray<FColor> BiomePixels;
-	BiomePixels.Reserve(64 * 64);
+        BiomePixels.Reserve(ExpectedSampleCount);
 	
 	for (const FBiomeResult& Result : BiomeData)
 	{

--- a/Source/Vibeheim/WorldGen/Private/Services/ClimateSystem.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/ClimateSystem.cpp
@@ -6,19 +6,40 @@
 
 DEFINE_LOG_CATEGORY_STATIC(LogClimateSystem, Log, All);
 
-UClimateSystem::UClimateSystem()
+namespace
 {
-	// Initialize with default settings
-	Settings = FClimateSettings();
-	Seed = 1337;
+static int32 ResolveSamplesPerTile(const FWorldGenConfig& Config, const TArray<float>& HeightData)
+{
+        if (HeightData.Num() > 0)
+        {
+                const float Root = FMath::Sqrt(static_cast<float>(HeightData.Num()));
+                const int32 RoundedRoot = FMath::RoundToInt(Root);
+                if (RoundedRoot > 0 && RoundedRoot * RoundedRoot == HeightData.Num())
+                {
+                        return RoundedRoot;
+                }
+        }
+
+        const float SampleSpacing = FMath::Max(Config.SampleSpacingMeters, KINDA_SMALL_NUMBER);
+        return FMath::Clamp(FMath::RoundToInt(Config.TileSizeMeters / SampleSpacing), 1, 4096);
+}
 }
 
-void UClimateSystem::Initialize(const FClimateSettings& InSettings, int32 InSeed)
+UClimateSystem::UClimateSystem()
 {
-	Settings = InSettings;
-	Seed = InSeed;
-	
-	UE_LOG(LogClimateSystem, Log, TEXT("Climate system initialized with seed %llu"), Seed);
+        // Initialize with default settings
+        Settings = FClimateSettings();
+        Seed = 1337;
+        CachedWorldGenConfig = FWorldGenConfig();
+}
+
+void UClimateSystem::Initialize(const FClimateSettings& InSettings, int32 InSeed, const FWorldGenConfig* InWorldGenConfig)
+{
+        Settings = InSettings;
+        Seed = InSeed;
+        CachedWorldGenConfig = InWorldGenConfig ? *InWorldGenConfig : FWorldGenConfig();
+
+        UE_LOG(LogClimateSystem, Log, TEXT("Climate system initialized with seed %llu"), Seed);
 }
 
 FClimateData UClimateSystem::CalculateClimate(FVector2D WorldPosition, float Altitude) const
@@ -93,23 +114,24 @@ TArray<FClimateData> UClimateSystem::GenerateTileClimateData(FTileCoord TileCoor
 {
 	TArray<FClimateData> ClimateDataArray;
 	
-	// Calculate tile world position
-	FVector TileWorldPos = TileCoord.ToWorldPosition(64.0f); // Using locked tile size
-	FVector2D TileStart(TileWorldPos.X - 32.0f, TileWorldPos.Y - 32.0f); // Start at corner
-	
-	// Generate climate data for each sample in the tile (64x64 samples)
-	const int32 SamplesPerTile = 64;
-	ClimateDataArray.Reserve(SamplesPerTile * SamplesPerTile);
-	
-	for (int32 Y = 0; Y < SamplesPerTile; Y++)
-	{
-		for (int32 X = 0; X < SamplesPerTile; X++)
-		{
-			// Calculate world position for this sample
-			FVector2D SampleWorldPos = TileStart + FVector2D(X, Y);
-			
-			// Get height for this sample (if height data is provided)
-			float SampleHeight = 0.0f;
+        const float TileSize = CachedWorldGenConfig.TileSizeMeters;
+        const FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+        const FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
+
+        const int32 SamplesPerTile = ResolveSamplesPerTile(CachedWorldGenConfig, HeightData);
+        const float EffectiveSpacing = SamplesPerTile > 0 ? TileSize / SamplesPerTile : CachedWorldGenConfig.SampleSpacingMeters;
+
+        ClimateDataArray.Reserve(SamplesPerTile * SamplesPerTile);
+
+        for (int32 Y = 0; Y < SamplesPerTile; Y++)
+        {
+                for (int32 X = 0; X < SamplesPerTile; X++)
+                {
+                        // Calculate world position for this sample
+                        FVector2D SampleWorldPos = TileStart + FVector2D(X * EffectiveSpacing, Y * EffectiveSpacing);
+
+                        // Get height for this sample (if height data is provided)
+                        float SampleHeight = 0.0f;
 			if (HeightData.IsValidIndex(Y * SamplesPerTile + X))
 			{
 				SampleHeight = HeightData[Y * SamplesPerTile + X];
@@ -126,14 +148,17 @@ TArray<FClimateData> UClimateSystem::GenerateTileClimateData(FTileCoord TileCoor
 
 bool UClimateSystem::ExportClimatePNG(FTileCoord TileCoord, const TArray<float>& HeightData, const FString& OutputPath) const
 {
-	// Generate climate data for the tile
-	TArray<FClimateData> ClimateData = GenerateTileClimateData(TileCoord, HeightData);
-	
-	if (ClimateData.Num() != 64 * 64)
-	{
-		UE_LOG(LogClimateSystem, Error, TEXT("Invalid climate data size for tile export"));
-		return false;
-	}
+        const int32 SamplesPerTile = ResolveSamplesPerTile(CachedWorldGenConfig, HeightData);
+        const int32 ExpectedSampleCount = SamplesPerTile * SamplesPerTile;
+
+        // Generate climate data for the tile
+        TArray<FClimateData> ClimateData = GenerateTileClimateData(TileCoord, HeightData);
+
+        if (ClimateData.Num() != ExpectedSampleCount)
+        {
+                UE_LOG(LogClimateSystem, Error, TEXT("Invalid climate data size for tile export"));
+                return false;
+        }
 	
 	// Create output directory if it doesn't exist
 	FString FullOutputPath = FPaths::ProjectDir() / OutputPath;
@@ -142,7 +167,7 @@ bool UClimateSystem::ExportClimatePNG(FTileCoord TileCoord, const TArray<float>&
 	// Export temperature map
 	{
 		TArray<FColor> TemperaturePixels;
-		TemperaturePixels.Reserve(64 * 64);
+                TemperaturePixels.Reserve(ExpectedSampleCount);
 		
 		for (const FClimateData& Data : ClimateData)
 		{
@@ -161,7 +186,7 @@ bool UClimateSystem::ExportClimatePNG(FTileCoord TileCoord, const TArray<float>&
 	// Export moisture map
 	{
 		TArray<FColor> MoisturePixels;
-		MoisturePixels.Reserve(64 * 64);
+                MoisturePixels.Reserve(ExpectedSampleCount);
 		
 		for (const FClimateData& Data : ClimateData)
 		{
@@ -178,7 +203,7 @@ bool UClimateSystem::ExportClimatePNG(FTileCoord TileCoord, const TArray<float>&
 	// Export ring bias map
 	{
 		TArray<FColor> RingPixels;
-		RingPixels.Reserve(64 * 64);
+                RingPixels.Reserve(ExpectedSampleCount);
 		
 		for (const FClimateData& Data : ClimateData)
 		{

--- a/Source/Vibeheim/WorldGen/Private/Services/HeightfieldService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/HeightfieldService.cpp
@@ -797,7 +797,12 @@ bool UHeightfieldService::ModifyHeightfield(FVector Location, float Radius, floa
 
 float UHeightfieldService::GetHeightAtLocation(FVector2D WorldPos)
 {
-	return InterpolateHeight(WorldPos);
+        return SampleHeightWorldXY(WorldPos);
+}
+
+float UHeightfieldService::SampleHeightWorldXY(FVector2D WorldXY) const
+{
+        return InterpolateHeight(WorldXY);
 }
 
 FVector UHeightfieldService::GetNormalAtLocation(FVector2D WorldPos)

--- a/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
@@ -1226,17 +1226,39 @@ void PCGWorldService::Private::ExtractInstancesFromPointData(const UPCGPointData
                         }
 
                         bool bMeshAssigned = false;
-                        FSoftObjectPath StaticMeshPath;
-                        if (Metadata->GetAttribute<FSoftObjectPath>(VHMPCGAttr::StaticMesh, EntryKey, StaticMeshPath) && !StaticMeshPath.IsNull())
+                        const FName MeshAttributes[] = { VHMPCGAttr::StaticMesh, VHMPCGAttr::Mesh };
+                        for (const FName& AttrName : MeshAttributes)
                         {
-                                Instance.Mesh = TSoftObjectPtr<UStaticMesh>(StaticMeshPath);
-                                bMeshAssigned = true;
+                                FSoftObjectPath StaticMeshPath;
+                                if (Metadata->GetAttribute<FSoftObjectPath>(AttrName, EntryKey, StaticMeshPath) && !StaticMeshPath.IsNull())
+                                {
+                                        Instance.Mesh = TSoftObjectPtr<UStaticMesh>(StaticMeshPath);
+                                        bMeshAssigned = true;
+                                        break;
+                                }
+
+                                UObject* MeshObject = nullptr;
+                                if (Metadata->GetAttribute<UObject*>(AttrName, EntryKey, MeshObject) && MeshObject)
+                                {
+                                        if (UStaticMesh* MeshPtr = Cast<UStaticMesh>(MeshObject))
+                                        {
+                                                UE_LOG(LogPCGWorldService, Warning,
+                                                        TEXT("Tile (%d, %d) attribute '%s' provided as object pointer. Use Soft Object Path in PCG graphs; pointer attrs can cause blending issues."),
+                                                        TileCoord.X, TileCoord.Y, *AttrName.ToString());
+                                                Instance.Mesh = TSoftObjectPtr<UStaticMesh>(MeshPtr);
+                                                bMeshAssigned = true;
+                                        }
+                                        else
+                                        {
+                                                UE_LOG(LogPCGWorldService, Error,
+                                                        TEXT("Tile (%d, %d) attribute '%s' must reference a UStaticMesh asset."),
+                                                        TileCoord.X, TileCoord.Y, *AttrName.ToString());
+                                        }
+
+                                        break;
+                                }
                         }
-                        else if (Metadata->GetAttribute<FSoftObjectPath>(VHMPCGAttr::Mesh, EntryKey, StaticMeshPath) && !StaticMeshPath.IsNull())
-                        {
-                                Instance.Mesh = TSoftObjectPtr<UStaticMesh>(StaticMeshPath);
-                                bMeshAssigned = true;
-                        }
+
                         if (!bMeshAssigned)
                         {
                                 const bool bHasStaticMeshAttr = Metadata->GetConstAttribute(VHMPCGAttr::StaticMesh) != nullptr;
@@ -1308,7 +1330,7 @@ void PCGWorldService::Private::ExtractInstancesFromPointData(const UPCGPointData
                 {
                         if (HeightfieldService)
                         {
-                                const float TerrainHeight = HeightfieldService->GetHeightAtLocation(FVector2D(Instance.Location.X, Instance.Location.Y));
+                                const float TerrainHeight = HeightfieldService->SampleHeightWorldXY(FVector2D(Instance.Location.X, Instance.Location.Y));
                                 if (FMath::IsFinite(TerrainHeight))
                                 {
                                         Instance.Location.Z = TerrainHeight;
@@ -3035,7 +3057,7 @@ float UPCGWorldService::ResolveBiomeBlendWeight(FTileCoord TileCoord, EBiomeType
         }
         else if (HeightfieldService)
         {
-                Altitude = HeightfieldService->GetHeightAtLocation(TileCenter2D);
+                Altitude = HeightfieldService->SampleHeightWorldXY(TileCenter2D);
         }
 
         const FBiomeResult BiomeResult = BiomeService->DetermineBiome(TileCenter2D, Altitude);

--- a/Source/Vibeheim/WorldGen/Private/Tests/WorldGenIntegrationTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/WorldGenIntegrationTest.cpp
@@ -2764,9 +2764,13 @@ FIntegrationTestResult UWorldGenIntegrationTest::RunPCGIntegrationTest()
 			return Result;
 		}
 		
-		// Define removal area (center quarter of the tile)
-		FVector TileCenter = AreaTestTile.ToWorldPosition(64.0f);
-		FBox RemovalArea(TileCenter - FVector(16.0f, 16.0f, 50.0f), TileCenter + FVector(16.0f, 16.0f, 50.0f));
+                const UWorldGenSettings* GlobalSettings = UWorldGenSettings::GetWorldGenSettings();
+                const float TileSizeMeters = GlobalSettings ? GlobalSettings->Settings.TileSizeMeters : 64.0f;
+                const float HalfExtentMeters = TileSizeMeters * 0.25f;
+
+                FVector TileCenter = AreaTestTile.ToWorldPosition(TileSizeMeters);
+                FBox RemovalArea(TileCenter - FVector(HalfExtentMeters, HalfExtentMeters, 50.0f),
+                        TileCenter + FVector(HalfExtentMeters, HalfExtentMeters, 50.0f));
 		
 		bool bAreaRemovalSuccess = PCGService->RemoveContentInArea(RemovalArea);
 		if (!bAreaRemovalSuccess)

--- a/Source/Vibeheim/WorldGen/Private/WorldGenManager.cpp
+++ b/Source/Vibeheim/WorldGen/Private/WorldGenManager.cpp
@@ -126,7 +126,7 @@ bool AWorldGenManager::InitializeWorldGenSystems()
 
 	// Initialize climate system with default settings
 	FClimateSettings ClimateSettings;
-	ClimateSystem->Initialize(ClimateSettings, WorldGenSettings->Settings.Seed);
+        ClimateSystem->Initialize(ClimateSettings, WorldGenSettings->Settings.Seed, &WorldGenSettings->Settings);
 
 	// Initialize Biome Service
 	BiomeService = NewObject<UBiomeService>(this);

--- a/Source/Vibeheim/WorldGen/Private/WorldGenTestSubsystem.cpp
+++ b/Source/Vibeheim/WorldGen/Private/WorldGenTestSubsystem.cpp
@@ -994,19 +994,21 @@ static bool ParseEditArgs(const TArray<FString>& Args, float& OutX, float& OutY,
     return true;
 }
 
-static TArray<FTileCoord> ComputeAffectedTiles(const FVector2D& Center, float Radius)
+static TArray<FTileCoord> ComputeAffectedTiles(const FVector2D& Center, float Radius, float TileSize)
 {
     TArray<FTileCoord> Result;
-    FTileCoord CenterTile = FTileCoord::FromWorldPosition(FVector(Center.X, Center.Y, 0.0f));
-    int32 TileRadius = FMath::CeilToInt(Radius / 64.0f);
-    const float TileDiagonal = 64.0f * FMath::Sqrt(2.0f);
+    TileSize = FMath::Max(TileSize, KINDA_SMALL_NUMBER);
+
+    FTileCoord CenterTile = FTileCoord::FromWorldPosition(FVector(Center.X, Center.Y, 0.0f), TileSize);
+    int32 TileRadius = FMath::CeilToInt(Radius / TileSize);
+    const float TileDiagonal = TileSize * FMath::Sqrt(2.0f);
 
     for (int32 y = CenterTile.Y - TileRadius; y <= CenterTile.Y + TileRadius; ++y)
     {
         for (int32 x = CenterTile.X - TileRadius; x <= CenterTile.X + TileRadius; ++x)
         {
             FTileCoord T(x, y);
-            FVector TileWorldPos = T.ToWorldPosition(64.0f);
+            FVector TileWorldPos = T.ToWorldPosition(TileSize);
             FVector2D TileCenter(TileWorldPos.X, TileWorldPos.Y);
             float Dist = FVector2D::Distance(Center, TileCenter);
             if (Dist <= Radius + TileDiagonal)
@@ -1097,7 +1099,10 @@ void UWorldGenTestSubsystem::ApplyEdit(EHeightfieldOperation Op, const TArray<FS
     if (VHM)
     {
         FVector2D Center(X, Y);
-        TArray<FTileCoord> Tiles = ComputeAffectedTiles(Center, Radius);
+        const UWorldGenSettings* Settings = UWorldGenSettings::GetWorldGenSettings();
+        const float TileSize = Settings ? Settings->Settings.TileSizeMeters : 64.0f;
+
+        TArray<FTileCoord> Tiles = ComputeAffectedTiles(Center, Radius, TileSize);
         int32 Updated = 0;
         for (const FTileCoord& T : Tiles)
         {
@@ -1285,7 +1290,7 @@ void UWorldGenTestSubsystem::ExecuteDeterminismTestCommand(const TArray<FString>
         EBiomeType BiomeType = LocalBiome->DetermineTileBiome(T, HFData.HeightData);
 
         // Climate at tile center (altitude = center height)
-        FVector TileWorldPos = T.ToWorldPosition(64.0f);
+        FVector TileWorldPos = T.ToWorldPosition(WGConfig.TileSizeMeters);
         FVector2D Center(TileWorldPos.X, TileWorldPos.Y);
         float CenterHeight = HFData.GetHeightAtSample(HFData.Resolution/2, HFData.Resolution/2);
         FClimateData Clim = LocalClimate->CalculateClimate(Center, CenterHeight);

--- a/Source/Vibeheim/WorldGen/Public/PCG/VibeheimPCGGetTerrainHeight.h
+++ b/Source/Vibeheim/WorldGen/Public/PCG/VibeheimPCGGetTerrainHeight.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PCGSettings.h"
+#include "Services/PCGWorldServiceTypes.h"
+#include "VibeheimPCGGetTerrainHeight.generated.h"
+
+class FPCGVibeheimGetTerrainHeightElement;
+
+/**
+ * PCG element settings that annotate points with terrain height and slope sampled from the heightfield service.
+ */
+UCLASS(BlueprintType, ClassGroup = (Vibeheim, PCG))
+class VIBEHEIM_API UVibeheimPCGGetTerrainHeightSettings : public UPCGSettings
+{
+        GENERATED_BODY()
+
+public:
+        UVibeheimPCGGetTerrainHeightSettings();
+
+        //~ Begin UPCGSettings interface
+        virtual TArray<FPCGPinProperties> InputPinProperties() const override;
+        virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
+        virtual FName GetDefaultNodeName() const override;
+        virtual FText GetDefaultNodeTitle() const override;
+        virtual EPCGSettingsType GetType() const override { return EPCGSettingsType::Spatial; }
+        virtual bool IsCacheable() const override { return false; }
+#if WITH_EDITOR
+        virtual FText GetNodeTooltipText() const override;
+#endif
+        virtual FPCGElementPtr CreateElement() const override;
+        //~ End UPCGSettings interface
+
+        /** Attribute name that will store the sampled terrain height. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Output")
+        FName HeightAttribute = VHMPCGAttr::TerrainHeight;
+
+        /** Attribute name that will store the sampled terrain slope in degrees. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Output")
+        FName SlopeAttribute = VHMPCGAttr::TerrainSlope;
+
+        /** When enabled, the point's Z location will be projected to the sampled height. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Output")
+        bool bProjectPointZ = false;
+};
+
+/**
+ * Runtime element that evaluates terrain height for incoming points.
+ */
+class FPCGVibeheimGetTerrainHeightElement : public FPCGDataProcessingElement
+{
+public:
+        virtual bool ExecuteInternal(FPCGContext* Context) const override;
+        virtual bool IsCacheable(const UPCGSettings* InSettings) const override { return false; }
+};

--- a/Source/Vibeheim/WorldGen/Public/Services/ClimateSystem.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/ClimateSystem.h
@@ -97,7 +97,7 @@ public:
 	 * Initialize the climate system with settings
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Climate")
-	void Initialize(const FClimateSettings& InSettings, int32 InSeed);
+        void Initialize(const FClimateSettings& InSettings, int32 InSeed, const FWorldGenConfig* InWorldGenConfig = nullptr);
 
 	/**
 	 * Calculate climate data for a specific world position
@@ -151,8 +151,11 @@ private:
 	UPROPERTY()
 	FClimateSettings Settings;
 
-	UPROPERTY()
-	int32 Seed;
+        UPROPERTY()
+        int32 Seed;
+
+        UPROPERTY()
+        FWorldGenConfig CachedWorldGenConfig;
 
 	/**
 	 * Calculate latitude-based temperature variation

--- a/Source/Vibeheim/WorldGen/Public/Services/HeightfieldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/HeightfieldService.h
@@ -97,9 +97,9 @@ public:
 	virtual bool Initialize(const FWorldGenConfig& Settings) override;
 	virtual FHeightfieldData GenerateHeightfield(int32 Seed, FTileCoord TileCoord) override;
 	virtual bool ModifyHeightfield(FVector Location, float Radius, float Strength, EHeightfieldOperation Operation) override;
-	virtual float GetHeightAtLocation(FVector2D WorldPos) override;
-	virtual FVector GetNormalAtLocation(FVector2D WorldPos) override;
-	virtual float GetSlopeAtLocation(FVector2D WorldPos) override;
+        virtual float GetHeightAtLocation(FVector2D WorldPos) override;
+        virtual FVector GetNormalAtLocation(FVector2D WorldPos) override;
+        virtual float GetSlopeAtLocation(FVector2D WorldPos) override;
 	virtual bool SaveHeightfieldModifications() override;
 	virtual bool LoadHeightfieldModifications() override;
 	virtual bool UploadHeightfieldToGPU(const FHeightfieldData& HeightfieldData) override;
@@ -151,7 +151,7 @@ public:
 	 * Load terrain modifications for a specific tile
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Persistence")
-	bool LoadTileTerrainDeltas(FTileCoord TileCoord);
+        bool LoadTileTerrainDeltas(FTileCoord TileCoord);
 
 	/**
 	 * Get all modifications affecting a specific tile
@@ -171,10 +171,15 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Persistence")
 	FString GetTerraDeltaPath(FTileCoord TileCoord) const;
 
-	/**
-	 * Sample height at world coordinates with consistent coordinate conversion (cm → sample index)
-	 */
-	float SampleHeightAt(FVector2D WorldXY, const TArray<float>& HeightData, FTileCoord TileCoord) const;
+        /**
+         * Sample height at world coordinates with consistent coordinate conversion (cm → sample index)
+         */
+        float SampleHeightAt(FVector2D WorldXY, const TArray<float>& HeightData, FTileCoord TileCoord) const;
+
+        /**
+         * Sample height directly from cached terrain data using world-space XY coordinates in meters.
+         */
+        float SampleHeightWorldXY(FVector2D WorldXY) const;
 
 private:
 	UPROPERTY()

--- a/Source/Vibeheim/WorldGen/Public/Services/PCGWorldServiceTypes.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/PCGWorldServiceTypes.h
@@ -43,6 +43,8 @@ namespace VHMPCGAttr
         inline const FName IsActive(TEXT("IsActive"));
         inline const FName InstanceId(TEXT("InstanceId"));
         inline const FName RespectGraphZ(TEXT("RespectGraphZ"));
+        inline const FName TerrainHeight(TEXT("TerrainHeight"));
+        inline const FName TerrainSlope(TEXT("TerrainSlope"));
 }
 
 /** Aggregated tile metrics computed prior to scheduling PCG graphs. */

--- a/Source/Vibeheim/WorldGen/Public/WorldGenManager.h
+++ b/Source/Vibeheim/WorldGen/Public/WorldGenManager.h
@@ -60,6 +60,8 @@ public:
 
     UPCGWorldService* GetPCGWorldService() const { return PCGWorldService; }
 
+    UHeightfieldService* GetHeightfieldService() const { return HeightfieldService; }
+
     /**
      * Handle world generation error fallback
      */


### PR DESCRIPTION
## Summary
- replace hard-coded 64m world conversions in biome, climate, and test subsystems with configurable tile size usage
- expose a cached SampleHeightWorldXY helper and use it when projecting PCG instances
- add a Vibeheim GetTerrainHeight PCG node that writes terrain height/slope metadata and optionally projects points

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6af73e1b4832a8706a27486b67eac