### PR TITLE
Use configured tile size for world-space conversions

### DIFF
--- a/Source/Vibeheim/WorldGen/Private/Services/BiomeService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/BiomeService.cpp
@@ -361,50 +361,50 @@ FBiomeResult UBiomeService::ApplyBiomeBlending(const TMap<EBiomeType, float>& Bi
 
 TArray<FBiomeResult> UBiomeService::GenerateTileBiomeData(FTileCoord TileCoord, const TArray<float>& HeightData) const
 {
-TArray<FBiomeResult> BiomeResults;
+        TArray<FBiomeResult> BiomeResults;
 
-const float TileSize = WorldGenSettings.TileSizeMeters;
-const FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
-const FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const FVector TileWorldPos = TileCoord.ToWorldPosition(TileSize);
+        const FVector2D TileStart(TileWorldPos.X - TileSize * 0.5f, TileWorldPos.Y - TileSize * 0.5f);
 
-int32 SamplesPerTile = 0;
-if (HeightData.Num() > 0)
-{
-const float Root = FMath::Sqrt(static_cast<float>(HeightData.Num()));
-const int32 RoundedRoot = FMath::RoundToInt(Root);
-if (RoundedRoot > 0 && RoundedRoot * RoundedRoot == HeightData.Num())
-{
-SamplesPerTile = RoundedRoot;
-}
-}
+        int32 SamplesPerTile = 0;
+        if (HeightData.Num() > 0)
+        {
+                const float Root = FMath::Sqrt(static_cast<float>(HeightData.Num()));
+                const int32 RoundedRoot = FMath::RoundToInt(Root);
+                if (RoundedRoot > 0 && RoundedRoot * RoundedRoot == HeightData.Num())
+                {
+                        SamplesPerTile = RoundedRoot;
+                }
+        }
 
-if (SamplesPerTile <= 0)
-{
-const float SampleSpacing = FMath::Max(WorldGenSettings.SampleSpacingMeters, KINDA_SMALL_NUMBER);
-SamplesPerTile = FMath::Clamp(FMath::RoundToInt(TileSize / SampleSpacing), 1, 4096);
-}
+        if (SamplesPerTile <= 0)
+        {
+                const float SampleSpacing = FMath::Max(WorldGenSettings.SampleSpacingMeters, KINDA_SMALL_NUMBER);
+                SamplesPerTile = FMath::Clamp(FMath::RoundToInt(TileSize / SampleSpacing), 1, 4096);
+        }
 
-const float EffectiveSpacing = SamplesPerTile > 0 ? TileSize / SamplesPerTile : WorldGenSettings.SampleSpacingMeters;
-BiomeResults.Reserve(SamplesPerTile * SamplesPerTile);
+        const float EffectiveSpacing = SamplesPerTile > 0 ? TileSize / SamplesPerTile : WorldGenSettings.SampleSpacingMeters;
+        BiomeResults.Reserve(SamplesPerTile * SamplesPerTile);
 
-for (int32 Y = 0; Y < SamplesPerTile; Y++)
-{
-for (int32 X = 0; X < SamplesPerTile; X++)
-{
-const FVector2D SampleWorldPos = TileStart + FVector2D(X * EffectiveSpacing, Y * EffectiveSpacing);
+        for (int32 Y = 0; Y < SamplesPerTile; Y++)
+        {
+                for (int32 X = 0; X < SamplesPerTile; X++)
+                {
+                        const FVector2D SampleWorldPos = TileStart + FVector2D(X * EffectiveSpacing, Y * EffectiveSpacing);
 
-float SampleHeight = 0.0f;
-if (HeightData.IsValidIndex(Y * SamplesPerTile + X))
-{
-SampleHeight = HeightData[Y * SamplesPerTile + X];
-}
+                        float SampleHeight = 0.0f;
+                        if (HeightData.IsValidIndex(Y * SamplesPerTile + X))
+                        {
+                                SampleHeight = HeightData[Y * SamplesPerTile + X];
+                        }
 
-const FBiomeResult BiomeResult = DetermineBiome(SampleWorldPos, SampleHeight);
-BiomeResults.Add(BiomeResult);
-}
-}
+                        const FBiomeResult BiomeResult = DetermineBiome(SampleWorldPos, SampleHeight);
+                        BiomeResults.Add(BiomeResult);
+                }
+        }
 
-return BiomeResults;
+        return BiomeResults;
 }
 
 bool UBiomeService::ExportBiomePNG(FTileCoord TileCoord, const TArray<float>& HeightData, const FString& OutputPath) const

--- a/Source/Vibeheim/WorldGen/Private/Services/HeightfieldService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/HeightfieldService.cpp
@@ -833,12 +833,12 @@ FVector UHeightfieldService::GetNormalAtLocation(FVector2D WorldPos)
 
 float UHeightfieldService::GetSlopeAtLocation(FVector2D WorldPos)
 {
-	FTileCoord TileCoord = FTileCoord::FromWorldPosition(FVector(WorldPos.X, WorldPos.Y, 0.0f));
-	FHeightfieldData HeightfieldData;
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        FTileCoord TileCoord = FTileCoord::FromWorldPosition(FVector(WorldPos.X, WorldPos.Y, 0.0f), TileSize);
+        FHeightfieldData HeightfieldData;
 
         if (GetCachedHeightfield(TileCoord, HeightfieldData))
         {
-                const float TileSize = WorldGenSettings.TileSizeMeters;
                 const float SampleSpacing = WorldGenSettings.SampleSpacingMeters;
                 const float InvSampleSpacing = 1.0f / FMath::Max(SampleSpacing, KINDA_SMALL_NUMBER);
 
@@ -852,12 +852,12 @@ float UHeightfieldService::GetSlopeAtLocation(FVector2D WorldPos)
                 return HeightfieldData.GetSlopeAtSample(X, Y);
         }
 
-	return 0.0f;
+        return 0.0f;
 }
 
 bool UHeightfieldService::SaveHeightfieldModifications()
 {
-	int32 SavedTiles = 0;
+        int32 SavedTiles = 0;
 
 	// Save all dirty tiles
 	for (const FTileCoord& TileCoord : DirtyTiles)

--- a/Source/Vibeheim/WorldGen/Private/Tests/CleanTerrainPersistenceTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/CleanTerrainPersistenceTest.cpp
@@ -42,7 +42,8 @@ static FAutoConsoleCommand CleanTerrainPersistenceTestCommand(
         
         UE_LOG(LogTemp, Warning, TEXT("Step 2: Apply 4 terrain modifications"));
         
-        FVector TestLocation = TestTile.ToWorldPosition();
+        const float TileSize = Config.TileSizeMeters;
+        FVector TestLocation = TestTile.ToWorldPosition(TileSize);
         
         // Apply 4 modifications (same as integration test but with smaller radius)
         FVector AddLocation = TestLocation + FVector(5.0f, 5.0f, 0.0f);

--- a/Source/Vibeheim/WorldGen/Private/Tests/FinalTerrainPersistenceTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/FinalTerrainPersistenceTest.cpp
@@ -42,7 +42,8 @@ static FAutoConsoleCommand FinalTerrainPersistenceTestCommand(
         
         UE_LOG(LogTemp, Warning, TEXT("Step 2: Apply 4 terrain modifications (including smooth)"));
         
-        FVector TestLocation = TestTile.ToWorldPosition();
+        const float TileSize = Config.TileSizeMeters;
+        FVector TestLocation = TestTile.ToWorldPosition(TileSize);
         
         // Apply the same 4 modifications as the integration test
         FVector AddLocation = TestLocation + FVector(5.0f, 5.0f, 0.0f);

--- a/Source/Vibeheim/WorldGen/Private/Tests/SimpleTerrainPersistenceTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/SimpleTerrainPersistenceTest.cpp
@@ -43,7 +43,8 @@ static FAutoConsoleCommand SimpleTerrainPersistenceTestCommand(
         UE_LOG(LogTemp, Warning, TEXT("Step 2: Apply single terrain modification"));
         
         // Apply just one modification to keep it simple
-        FVector TestLocation = TestTile.ToWorldPosition();
+        const float TileSize = Config.TileSizeMeters;
+        FVector TestLocation = TestTile.ToWorldPosition(TileSize);
         FVector ModLocation = TestLocation; // Center of tile
         
         bool bModSuccess = HeightfieldService->ModifyHeightfield(ModLocation, EditRadius, EditStrength, EHeightfieldOperation::Add);

--- a/Source/Vibeheim/WorldGen/Private/Tests/SmoothOperationTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/SmoothOperationTest.cpp
@@ -42,7 +42,8 @@ static FAutoConsoleCommand SmoothOperationTestCommand(
         
         UE_LOG(LogTemp, Warning, TEXT("Step 2: Apply modifications with smooth operation"));
         
-        FVector TestLocation = TestTile.ToWorldPosition();
+        const float TileSize = Config.TileSizeMeters;
+        FVector TestLocation = TestTile.ToWorldPosition(TileSize);
         
         // Apply Add operation first to create some variation
         FVector AddLocation = TestLocation + FVector(5.0f, 5.0f, 0.0f);

--- a/Source/Vibeheim/WorldGen/Private/Tests/StructInitializationIntegrationTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/StructInitializationIntegrationTest.cpp
@@ -729,8 +729,11 @@ bool FStructInitializationIntegrationTestBase::TestCrossSystemWorkflowIntegratio
 		
 		// Step 3: Create PCG instances around POIs
 		TArray<FPCGInstanceData> WorkflowInstances;
-		for (const FPOIData& POI : WorkflowPOIs)
-		{
+                const UWorldGenSettings* GlobalSettings = UWorldGenSettings::GetWorldGenSettings();
+                const float TileSize = GlobalSettings ? GlobalSettings->Settings.TileSizeMeters : 64.0f;
+
+                for (const FPOIData& POI : WorkflowPOIs)
+                {
 			// Create instances in a circle around each POI
 			for (int32 i = 0; i < 8; i++)
 			{
@@ -744,7 +747,7 @@ bool FStructInitializationIntegrationTestBase::TestCrossSystemWorkflowIntegratio
 					0.0f
 				);
 				Instance.Rotation = FRotator(0.0f, Angle, 0.0f);
-				Instance.OwningTile = FTileCoord::FromWorldPosition(Instance.Location);
+                                Instance.OwningTile = FTileCoord::FromWorldPosition(Instance.Location, TileSize);
 				Instance.bIsActive = true;
 				
 				if (!Instance.InstanceId.IsValid())

--- a/Source/Vibeheim/WorldGen/Private/Tests/TerrainPersistenceConsoleTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/TerrainPersistenceConsoleTest.cpp
@@ -42,7 +42,8 @@ static FAutoConsoleCommand TestTerrainPersistenceCommand(
         UE_LOG(LogTemp, Warning, TEXT("Step 2: Apply terrain modifications"));
         
         // Apply modifications (same sequence as integration test)
-        FVector TestLocation = TestTile.ToWorldPosition();
+        const float TileSize = Config.TileSizeMeters;
+        FVector TestLocation = TestTile.ToWorldPosition(TileSize);
         
         // Operation 1: Add terrain
         FVector AddLocation = TestLocation + FVector(5.0f, 5.0f, 0.0f);

--- a/Source/Vibeheim/WorldGen/Private/Tests/UltimateTerrainPersistenceTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/UltimateTerrainPersistenceTest.cpp
@@ -52,7 +52,8 @@ static FAutoConsoleCommand UltimateTerrainPersistenceTestCommand(
         
         UE_LOG(LogTemp, Warning, TEXT("Step 2: Apply 4 terrain modifications"));
         
-        FVector TestLocation = TestTile.ToWorldPosition();
+        const float TileSize = Config.TileSizeMeters;
+        FVector TestLocation = TestTile.ToWorldPosition(TileSize);
         
         // Apply 4 modifications with smaller radius to stay within tile bounds
         FVector AddLocation = TestLocation + FVector(4.0f, 4.0f, 0.0f);

--- a/Source/Vibeheim/WorldGen/Private/Tests/WorldGenIntegrationTest.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Tests/WorldGenIntegrationTest.cpp
@@ -1981,7 +1981,8 @@ FIntegrationTestResult UWorldGenIntegrationTest::RunPersistenceTest()
 			InitialHeightfield.HeightData.Num() * sizeof(float));
 		
 		// Step 2: Apply all 4 terrain editing operations
-		FVector TestLocation = TestTile.ToWorldPosition();
+                const float TileSize = WorldGenSettings ? WorldGenSettings->Settings.TileSizeMeters : 64.0f;
+                FVector TestLocation = TestTile.ToWorldPosition(TileSize);
 		float EditRadius = TestConfig.TerrainEditRadius;
 		float EditStrength = TestConfig.TerrainEditStrength;
 		
@@ -3256,7 +3257,8 @@ FIntegrationTestResult UWorldGenIntegrationTest::RunPOIIntegrationTest()
 		TestRule.MinDistanceFromOthers = 50.0f;
 		
 		// Test a location that should be valid (center of tile with gentle terrain)
-		FVector TestLocation = TestTile.ToWorldPosition();
+                const float TileSize = WorldGenSettings ? WorldGenSettings->Settings.TileSizeMeters : 64.0f;
+                FVector TestLocation = TestTile.ToWorldPosition(TileSize);
 		TestLocation.Z = 50.0f; // Set a reasonable altitude
 		
 		bool bValidPlacement = POIService->ValidatePOIPlacement(TestLocation, TestRule, TestHeightData, TestTile);

--- a/Source/Vibeheim/WorldGen/Private/VHMTerrainRendering/TerrainLODManager.cpp
+++ b/Source/Vibeheim/WorldGen/Private/VHMTerrainRendering/TerrainLODManager.cpp
@@ -2,6 +2,7 @@
 #include "Engine/World.h"
 #include "Engine/Engine.h"
 #include "Logging/LogMacros.h"
+#include "Data/WorldGenTypes.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogTerrainLOD, Log, All);
 
@@ -370,7 +371,8 @@ void UVHMTerrainLODManager::RunBasicValidationTest()
     FTileCoord TestTile(0, 0);
     FVector TestViewerPos(100.0f, 100.0f, 50.0f);
     
-    float TestDistance = FVector::Dist(TestViewerPos, TestTile.ToWorldPosition(64.0f));
+    const FWorldGenConfig DefaultConfig;
+    float TestDistance = FVector::Dist(TestViewerPos, TestTile.ToWorldPosition(DefaultConfig.TileSizeMeters));
     UE_LOG(LogTerrainLOD, Log, TEXT("Test tile (0,0) distance from viewer (100,100,50): %.1fm"), TestDistance);
     
     // Determine expected LOD level

--- a/Source/Vibeheim/WorldGen/Public/Data/CoordinateSystem.md
+++ b/Source/Vibeheim/WorldGen/Public/Data/CoordinateSystem.md
@@ -26,16 +26,16 @@ struct FTileCoord {
     int32 X, Y;
     
     // Convert world position to tile coordinate
-    static FTileCoord FromWorldPosition(FVector WorldPos, float TileSize = 64.0f);
+    static FTileCoord FromWorldPosition(FVector WorldPos, float TileSize);
     
     // Convert tile coordinate to world center position
-    FVector ToWorldPosition(float TileSize = 64.0f) const;
+    FVector ToWorldPosition(float TileSize) const;
 };
 ```
 
 ### Coordinate Conversion
-- **World to Tile**: `TileX = floor(WorldX / 64.0f)`, `TileY = floor(WorldY / 64.0f)`
-- **Tile to World**: `WorldX = (TileX + 0.5f) * 64.0f`, `WorldY = (TileY + 0.5f) * 64.0f`
+- **World to Tile**: `TileX = floor(WorldX / TileSize)`, `TileY = floor(WorldY / TileSize)`
+- **Tile to World**: `WorldX = (TileX + 0.5f) * TileSize`, `WorldY = (TileY + 0.5f) * TileSize`
 - Tile coordinates represent the tile containing a world position
 - Tile-to-world conversion returns the center of the tile
 

--- a/Source/Vibeheim/WorldGen/Public/Data/WorldGenTypes.h
+++ b/Source/Vibeheim/WorldGen/Public/Data/WorldGenTypes.h
@@ -41,7 +41,7 @@ struct VIBEHEIM_API FTileCoord
 	FTileCoord(FIntVector2 InCoord) : X(InCoord.X), Y(InCoord.Y) {}
 
         // Convert world position to tile coordinate
-        static FTileCoord FromWorldPosition(FVector WorldPos, float TileSize = 64.0f)
+        static FTileCoord FromWorldPosition(FVector WorldPos, float TileSize)
         {
                 return FTileCoord(
                         FMath::FloorToInt(WorldPos.X / TileSize),
@@ -55,7 +55,7 @@ struct VIBEHEIM_API FTileCoord
         }
 
         // Convert tile coordinate to world position (center of tile)
-        FVector ToWorldPosition(float TileSize = 64.0f) const
+        FVector ToWorldPosition(float TileSize) const
         {
                 return FVector(
                         (X + 0.5f) * TileSize,


### PR DESCRIPTION
## Summary
- remove the 64 m default from FTileCoord::FromWorldPosition/ToWorldPosition to require explicit tile sizes
- update world-gen services, utilities, and tests to pass WorldGenSettings.TileSizeMeters instead of hardcoded 64 m values
- refresh documentation and debug helpers to reference the configurable tile size

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6c6bf4a78832a9cd455b70b87d660