### PR TITLE
Remove duplicate PCG world service initialization block

### DIFF
--- a/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
@@ -1495,12 +1495,17 @@ UPCGWorldService::FAttributeValidationResult UPCGWorldService::ValidateInputAttr
 
 #endif
 
-bool UPCGWorldService::Initialize(const FWorldGenConfig& Settings)
+void UPCGWorldService::ApplyWorldGenSettings(const FWorldGenConfig& Settings)
 {
         WorldGenSettings = Settings;
         MaxInstancesPerTile = Settings.MaxHISMInstances;
         bAllowHeadlessLogicalInstances = Settings.bAllowHeadlessLogicalInstances;
         InitializeDefaultBiomes();
+}
+
+bool UPCGWorldService::Initialize(const FWorldGenConfig& Settings)
+{
+        ApplyWorldGenSettings(Settings);
 
 #if WITH_AUTOMATION_TESTS && VHM_PCG_ENABLED
         if (TestWorldOverride.IsValid())

--- a/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
@@ -285,10 +285,15 @@ private:
 	 */
 	void UpdatePerformanceStats(float GenerationTimeMs, int32 InstanceCount);
 
-	/**
-	 * Initialize default biome definitions
-	 */
-	void InitializeDefaultBiomes();
+        /**
+         * Apply configuration settings from the world generation config.
+         */
+        void ApplyWorldGenSettings(const FWorldGenConfig& Settings);
+
+        /**
+         * Initialize default biome definitions
+         */
+        void InitializeDefaultBiomes();
 
 	/**
 	 * Initialize default biome definitions with vegetation rules (for merging)


### PR DESCRIPTION
## Summary
- consolidate the repeated configuration assignment in `UPCGWorldService::Initialize` into a dedicated `ApplyWorldGenSettings` helper
- expose the helper in the header so the world service applies default biomes and limits only once

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e72f8f0810832a9477b239784071ad