### PR TITLE
Add static engine guard and prewarm biome assets

### DIFF
--- a/Source/Vibeheim/Vibeheim.cpp
+++ b/Source/Vibeheim/Vibeheim.cpp
@@ -3,6 +3,7 @@
 #include "Vibeheim.h"
 #include "Modules/ModuleManager.h"
 
-static_assert(ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 6, "Requires UE 5.6.x");
+static_assert(ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 6,
+              "Vibeheim requires Unreal Engine 5.6.x");
 
 IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, Vibeheim, "Vibeheim" );

--- a/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/PCGWorldService.cpp
@@ -8,6 +8,9 @@
 #include "Components/SceneComponent.h"
 #include "Algo/Sort.h"
 #include "PCGVersionGuard.h"
+#include "Engine/AssetManager.h"
+#include "Engine/StreamableManager.h"
+#include "Kismet/GameplayStatics.h"
 
 #if VHM_PCG_ENABLED
 #include "PCGComponent.h"
@@ -31,6 +34,7 @@
 #include "Async/TaskGraphInterfaces.h"
 #include "Async/Async.h"
 #include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "UObject/ConstructorHelpers.h"
 #include "Data/InstancePersistence.h"
 #include "Data/SerializationShims.h"
@@ -1805,6 +1809,7 @@ FPCGGenerationData UPCGWorldService::GeneratePCGContent(FTileCoord TileCoord, EB
 
     const uint32 TileSeed = GetTileRandomSeed(TileCoord);
     const float BiomeBlendWeight = ResolveBiomeBlendWeight(TileCoord, BiomeType, EffectiveMetrics);
+    PrewarmBiomeAssets(TileCoord, BiomeType);
     UObject* DataOuter = AnchorActor ? static_cast<UObject*>(AnchorActor) : static_cast<UObject*>(this);
     UPCGParamData* ParameterData = Private::CreateTileParameterData(DataOuter, EffectiveMetrics ? *EffectiveMetrics : FPCGTileMetrics(), TileCoord, BiomeType, WorldGenSettings, TileSeed, DensityScale, BiomeBlendWeight);
     UPCGPointData* TilePointData = Private::CreateTilePointData(DataOuter, TileCoord, WorldGenSettings, EffectiveMetrics ? *EffectiveMetrics : FPCGTileMetrics());
@@ -1994,6 +1999,7 @@ FPCGGenerationData UPCGWorldService::GenerateFallbackContent(FTileCoord TileCoor
         FPCGSpawnParams SpawnParams;
         const float BiomeBlendWeight = ResolveBiomeBlendWeight(TileCoord, BiomeType, EffectiveMetrics);
         SpawnParams.BiomeWeightScale = BiomeBlendWeight;
+        PrewarmBiomeAssets(TileCoord, BiomeType);
 
         if (bHeadless && bAllowHeadlessLogicalInstances)
         {
@@ -3093,6 +3099,82 @@ float UPCGWorldService::ResolveBiomeBlendWeight(FTileCoord TileCoord, EBiomeType
         }
 
         return FMath::Clamp(Weight, 0.0f, 1.0f);
+}
+
+void UPCGWorldService::PrewarmBiomeAssets(FTileCoord TileCoord, EBiomeType BiomeType)
+{
+        if (BiomeType == EBiomeType::None)
+        {
+                return;
+        }
+
+        UWorld* World = GetWorld();
+        if (!World)
+        {
+                return;
+        }
+
+        const APawn* PlayerPawn = UGameplayStatics::GetPlayerPawn(World, 0);
+        if (!PlayerPawn)
+        {
+                return;
+        }
+
+        const FVector PlayerLocation = PlayerPawn->GetActorLocation();
+        const FVector TileCenter = TileCoord.ToWorldPosition(WorldGenSettings.TileSizeMeters);
+        const float PrewarmRadius = WorldGenSettings.TileSizeMeters * 3.0f;
+        if (FVector::DistSquared2D(PlayerLocation, TileCenter) > FMath::Square(PrewarmRadius))
+        {
+                return;
+        }
+
+        const FBiomeDefinition* BiomeDef = BiomeDefinitions.Find(BiomeType);
+
+        TArray<FSoftObjectPath> AssetsToStream;
+        auto QueueAsset = [this, &AssetsToStream](const auto& AssetPtr)
+        {
+                if (AssetPtr.IsNull() || AssetPtr.IsValid())
+                {
+                        return;
+                }
+
+                const FSoftObjectPath AssetPath = AssetPtr.ToSoftObjectPath();
+                if (!AssetPath.IsValid() || PrewarmedAssetPaths.Contains(AssetPath))
+                {
+                        return;
+                }
+
+                AssetsToStream.Add(AssetPath);
+                PrewarmedAssetPaths.Add(AssetPath);
+        };
+
+        if (const TSoftObjectPtr<UPCGGraph>* GraphPtr = BiomePCGGraphs.Find(BiomeType))
+        {
+                QueueAsset(*GraphPtr);
+        }
+
+        if (BiomeDef)
+        {
+                QueueAsset(BiomeDef->BiomePCGGraph);
+
+                for (const FPCGVegetationRule& VegRule : BiomeDef->VegetationRules)
+                {
+                        QueueAsset(VegRule.VegetationMesh);
+                }
+
+                for (const FPOISpawnRule& POIRule : BiomeDef->POIRules)
+                {
+                        QueueAsset(POIRule.POIBlueprint);
+                }
+        }
+
+        if (AssetsToStream.Num() == 0)
+        {
+                return;
+        }
+
+        FStreamableManager& Streamable = UAssetManager::GetStreamableManager();
+        Streamable.RequestAsyncLoad(AssetsToStream, FStreamableDelegate(), FStreamableManager::AsyncLoadHighPriority);
 }
 
 bool UPCGWorldService::AddPOI(const FPOIData& POIData)

--- a/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/PCGWorldService.h
@@ -9,6 +9,7 @@
 #include "Components/HierarchicalInstancedStaticMeshComponent.h"
 #include "Data/SerializationShims.h"
 #include "HAL/IConsoleManager.h"
+#include "UObject/SoftObjectPath.h"
 #include "PCGWorldService.generated.h"
 
 UE_DECLARE_LOG_CATEGORY_EXTERN(LogPCGWorldService, Log, All);
@@ -194,10 +195,12 @@ private:
 	UPROPERTY()
 	int32 MaxInstancesPerTile;
 
-	UPROPERTY()
+        UPROPERTY()
         TArray<float> CullDistances;
 
-	// PCG-related properties (always declared but only used when WITH_PCG is true)
+        TSet<FSoftObjectPath> PrewarmedAssetPaths;
+
+        // PCG-related properties (always declared but only used when WITH_PCG is true)
         UPROPERTY()
         TObjectPtr<UObject> CurrentPCGGraph; // UPCGGraph* when WITH_PCG is available
 
@@ -318,6 +321,8 @@ private:
         float EstimateWorkUnitsForBiome(EBiomeType BiomeType, const FPCGTileMetrics* TileMetrics) const;
 
         float ComputeDensityScaleFromWork(float EstimatedWorkUnits) const;
+
+        void PrewarmBiomeAssets(FTileCoord TileCoord, EBiomeType BiomeType);
 
 	UPCGGraph* ResolveBiomePCGGraph(EBiomeType BiomeType);
 


### PR DESCRIPTION
## Summary
- enforce Unreal Engine 5.6.x at compile time via static assert
- asynchronously prewarm biome PCG graphs, vegetation meshes, and POI blueprints near the player
- reuse the prewarm path for both PCG and fallback generation while tracking already requested assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7e7679ef4832aa11d19fbb2b0186a