### PR TITLE
Enhance POI stamping and streaming telemetry

### DIFF
--- a/.kiro/specs/valheim-world-generation/tasks.md
+++ b/.kiro/specs/valheim-world-generation/tasks.md
@@ -125,7 +125,7 @@
   - Implement cross-tile POI distance checking
   - _Requirements: 6_
 
-- [ ] 11.2 Enhance terrain stamping operations
+- [x] 11.2 Enhance terrain stamping operations
   - Implement ApplyTerrainStamp with operation types (raise, lower, smooth, flatten)
   - Ensure stamping operations integrate with HeightfieldService persistence
   - Add cross-tile stamping support for large POIs
@@ -143,7 +143,7 @@
 **Note:** Budgeted streaming pipeline with prefetch queues is implemented. Performance monitoring methods need implementation.
 
 - [ ] 12. Complete AsyncGenerationPipeline performance monitoring
-- [ ] 12.1 Implement activation spike detection
+- [x] 12.1 Implement activation spike detection
   - Implement `SampleFrameTime()` to track frame time samples over rolling window (~3s)
   - Implement `ComputeRecentSpikeMs()` to detect spikes exceeding +8ms threshold relative to baseline
   - Log spike events with tile coordinates and timing details
@@ -151,7 +151,7 @@
   - Call spike detection in `NotifyVHMRenderer` or `UpdateStreaming`
   - _Requirements: 7, 8_
 
-- [ ] 12.2 Implement ExportPerformanceCSV functionality
+- [x] 12.2 Implement ExportPerformanceCSV functionality
   - Implement `UTileStreamingService::ExportPerformanceCSV()` method body
   - Export per-tile metrics: TileCoord, GenMs, PCGMs, StreamInMs, GTOverheadMs, ThreadSpikesMs
   - Write CSV to `Saved/Vibeheim/WorldGen/Perf/<timestamp>_perf.csv` with headers

--- a/Source/Vibeheim/WorldGen/Private/Services/POIService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/POIService.cpp
@@ -56,7 +56,7 @@ bool UPOIService::Initialize(const FWorldGenConfig& Settings)
 	return true;
 }
 
-TArray<FPOIData> UPOIService::GenerateTilePOIs(FTileCoord TileCoord, EBiomeType BiomeType, const TArray<float>& HeightData)
+TArray<FPOIData> UPOIService::GenerateTilePOIs(FTileCoord TileCoord, EBiomeType BiomeType, TArray<float>& HeightData)
 {
 	double StartTime = FPlatformTime::Seconds();
 	TArray<FPOIData> GeneratedPOIs;
@@ -138,18 +138,31 @@ TArray<FPOIData> UPOIService::GenerateTilePOIs(FTileCoord TileCoord, EBiomeType 
 
 			// Check distance requirements
 			float ReservationRadius = GetReservationRadiusMeters(Rule);
-			// Create POI data
-			FPOIData NewPOI;
-			NewPOI.POIName = Rule.POIName;
-			NewPOI.Location = WorldLocation;
-			NewPOI.Location.Z = GetHeightAtTileLocation(WorldToTileLocal(WorldLocation, TileCoord), HeightData, TileCoord);
-			NewPOI.POIBlueprint = Rule.POIBlueprint;
-			NewPOI.OriginBiome = BiomeType;
-			
-			GeneratedPOIs.Add(NewPOI);
-			AllPOIs.Add(NewPOI.POIId, NewPOI);
-			RemovedPOIs.Remove(NewPOI.POIId);
-			ReserveLocationForPOI(NewPOI, ReservationRadius, Rule);
+                        // Create POI data and apply terrain stamp if requested
+                        FPOIData NewPOI;
+                        NewPOI.POIName = Rule.POIName;
+                        NewPOI.Location = WorldLocation;
+                        NewPOI.POIBlueprint = Rule.POIBlueprint;
+                        NewPOI.OriginBiome = BiomeType;
+
+                        const FPOITerrainStampSettings& StampSettings = Rule.TerrainStampSettings;
+                        if (StampSettings.Operation != EPOITerrainStampMode::None)
+                        {
+                                if (!ApplyTerrainStamp(WorldLocation, ReservationRadius, HeightData, TileCoord, StampSettings))
+                                {
+                                        UE_LOG(LogPOIService, Warning, TEXT("Failed to apply terrain stamp for POI '%s' at (%.1f, %.1f)"),
+                                                *Rule.POIName, WorldLocation.X, WorldLocation.Y);
+                                        continue;
+                                }
+                        }
+
+                        // Sample updated height after stamping
+                        NewPOI.Location.Z = GetHeightAtTileLocation(WorldToTileLocal(NewPOI.Location, TileCoord), HeightData, TileCoord);
+
+                        GeneratedPOIs.Add(NewPOI);
+                        AllPOIs.Add(NewPOI.POIId, NewPOI);
+                        RemovedPOIs.Remove(NewPOI.POIId);
+                        ReserveLocationForPOI(NewPOI, ReservationRadius, Rule);
 			if (Rule.bUniquePerWorld)
 			{
 				NewlySpawnedUniqueNames.Add(Rule.POIName);
@@ -238,75 +251,122 @@ bool UPOIService::CheckPOIDistanceRequirements(FVector Location, const FPOISpawn
 
 bool UPOIService::ApplyTerrainStamp(FVector Location, float Radius, TArray<float>& HeightData, FTileCoord TileCoord, const FPOITerrainStampSettings& StampSettings)
 {
-	const float EffectiveRadius = (StampSettings.RadiusMeters > KINDA_SMALL_NUMBER) ? StampSettings.RadiusMeters : Radius;
-	if (EffectiveRadius <= KINDA_SMALL_NUMBER)
-	{
-		UE_LOG(LogPOIService, Warning, TEXT("ApplyTerrainStamp skipped due to non-positive radius (%.2f)"), EffectiveRadius);
-		return false;
-	}
+        const float EffectiveRadius = (StampSettings.RadiusMeters > KINDA_SMALL_NUMBER) ? StampSettings.RadiusMeters : Radius;
+        if (EffectiveRadius <= KINDA_SMALL_NUMBER)
+        {
+                UE_LOG(LogPOIService, Warning, TEXT("ApplyTerrainStamp skipped due to non-positive radius (%.2f)"), EffectiveRadius);
+                return false;
+        }
 
-	// Determine operation and strength defaults
-	EPOITerrainStampMode Operation = StampSettings.Operation == EPOITerrainStampMode::None
-		? EPOITerrainStampMode::Flatten
-		: StampSettings.Operation;
+        // Determine operation and strength defaults
+        EPOITerrainStampMode Operation = StampSettings.Operation == EPOITerrainStampMode::None
+                ? EPOITerrainStampMode::Flatten
+                : StampSettings.Operation;
 
-	float Strength = StampSettings.Strength;
-	if (Strength <= KINDA_SMALL_NUMBER)
-	{
-		Strength = ValidationSettings.TerrainStampStrength;
-	}
-	Strength = FMath::Clamp(Strength, 0.0f, 1.0f);
+        float Strength = StampSettings.Strength;
+        if (Strength <= KINDA_SMALL_NUMBER)
+        {
+                Strength = ValidationSettings.TerrainStampStrength;
+        }
+        Strength = FMath::Clamp(Strength, 0.0f, 1.0f);
 
-	FVector2D LocalPos = WorldToTileLocal(Location, TileCoord);
+        const FVector2D LocalPos = WorldToTileLocal(Location, TileCoord);
+        const float TileHalfSize = WorldGenSettings.TileSizeMeters * 0.5f;
+        const bool bTouchesNeighborTiles = StampSettings.bAffectNeighborTiles
+                || (FMath::Abs(LocalPos.X) + EffectiveRadius > TileHalfSize)
+                || (FMath::Abs(LocalPos.Y) + EffectiveRadius > TileHalfSize);
 
-	switch (Operation)
-	{
-	case EPOITerrainStampMode::Flatten:
-		ApplyFlatteningStamp(LocalPos, EffectiveRadius, Strength, HeightData, TileCoord);
-		break;
-	case EPOITerrainStampMode::Raise:
-		ApplyRaiseStamp(LocalPos, EffectiveRadius, Strength, StampSettings.RaiseHeightMeters, HeightData, TileCoord);
-		break;
-	case EPOITerrainStampMode::Smooth:
-		ApplySmoothStamp(LocalPos, EffectiveRadius, FMath::Max(StampSettings.SmoothIterations, 1), HeightData, TileCoord);
-		break;
-	default:
-		UE_LOG(LogPOIService, Warning, TEXT("ApplyTerrainStamp received unsupported operation (%d)"), static_cast<int32>(Operation));
-		return false;
-	}
+        auto ResolveHeightOperation = [&](EHeightfieldOperation& OutOperation, float& OutStrength)
+        {
+                switch (Operation)
+                {
+                case EPOITerrainStampMode::Flatten:
+                        OutOperation = EHeightfieldOperation::Flatten;
+                        OutStrength = Strength;
+                        return Strength > KINDA_SMALL_NUMBER;
+                case EPOITerrainStampMode::Raise:
+                        OutOperation = EHeightfieldOperation::Add;
+                        OutStrength = StampSettings.RaiseHeightMeters * Strength;
+                        return OutStrength > KINDA_SMALL_NUMBER;
+                case EPOITerrainStampMode::Lower:
+                        OutOperation = EHeightfieldOperation::Subtract;
+                        OutStrength = StampSettings.LowerDepthMeters * Strength;
+                        return OutStrength > KINDA_SMALL_NUMBER;
+                case EPOITerrainStampMode::Smooth:
+                        OutOperation = EHeightfieldOperation::Smooth;
+                        OutStrength = Strength;
+                        return Strength > KINDA_SMALL_NUMBER;
+                default:
+                        return false;
+                }
+        };
 
-	// Record modification with heightfield service to persist across tiles/world loads
-	if (HeightfieldService)
-	{
-		EHeightfieldOperation HeightOp = EHeightfieldOperation::Flatten;
-		float PersistenceStrength = Strength;
+        bool bApplied = false;
+        bool bAppliedViaService = false;
+        EHeightfieldOperation HeightOp = EHeightfieldOperation::Flatten;
+        float PersistenceStrength = Strength;
+        const bool bHasValidHeightOp = ResolveHeightOperation(HeightOp, PersistenceStrength);
 
-		switch (Operation)
-		{
-		case EPOITerrainStampMode::Flatten:
-			HeightOp = EHeightfieldOperation::Flatten;
-			break;
-		case EPOITerrainStampMode::Raise:
-			HeightOp = EHeightfieldOperation::Add;
-			PersistenceStrength = StampSettings.RaiseHeightMeters * Strength;
-			break;
-		case EPOITerrainStampMode::Smooth:
-			HeightOp = EHeightfieldOperation::Smooth;
-			break;
-		default:
-			break;
-		}
+        if (HeightfieldService && bHasValidHeightOp)
+        {
+                if (HeightfieldService->ModifyHeightfield(Location, EffectiveRadius, PersistenceStrength, HeightOp))
+                {
+                        SyncHeightDataFromService(TileCoord, HeightData);
+                        bApplied = true;
+                        bAppliedViaService = true;
+                }
+                else
+                {
+                        UE_LOG(LogPOIService, Warning, TEXT("ModifyHeightfield failed for stamp operation %s at (%.1f, %.1f)"),
+                                *UEnum::GetDisplayValueAsText(Operation).ToString(), Location.X, Location.Y);
+                }
+        }
 
-		if (PersistenceStrength > KINDA_SMALL_NUMBER)
-		{
-			HeightfieldService->ModifyHeightfield(Location, EffectiveRadius, PersistenceStrength, HeightOp);
-		}
-	}
+        if (!bAppliedViaService)
+        {
+                switch (Operation)
+                {
+                case EPOITerrainStampMode::Flatten:
+                        ApplyFlatteningStamp(LocalPos, EffectiveRadius, Strength, HeightData, TileCoord);
+                        break;
+                case EPOITerrainStampMode::Raise:
+                        ApplyRaiseStamp(LocalPos, EffectiveRadius, Strength, StampSettings.RaiseHeightMeters, HeightData, TileCoord);
+                        break;
+                case EPOITerrainStampMode::Lower:
+                        ApplyLowerStamp(LocalPos, EffectiveRadius, Strength, StampSettings.LowerDepthMeters, HeightData, TileCoord);
+                        break;
+                case EPOITerrainStampMode::Smooth:
+                        ApplySmoothStamp(LocalPos, EffectiveRadius, FMath::Max(StampSettings.SmoothIterations, 1), HeightData, TileCoord);
+                        break;
+                default:
+                        UE_LOG(LogPOIService, Warning, TEXT("ApplyTerrainStamp received unsupported operation (%d)"), static_cast<int32>(Operation));
+                        return false;
+                }
 
-	UE_LOG(LogPOIService, Verbose, TEXT("Applied %s terrain stamp at (%.1f, %.1f, %.1f) with radius %.1f (strength %.2f)"),
-		*UEnum::GetDisplayValueAsText(Operation).ToString(), Location.X, Location.Y, Location.Z, EffectiveRadius, Strength);
+                bApplied = true;
 
-	return true;
+                if (HeightfieldService && bHasValidHeightOp)
+                {
+                        if (HeightfieldService->ModifyHeightfield(Location, EffectiveRadius, PersistenceStrength, HeightOp))
+                        {
+                                SyncHeightDataFromService(TileCoord, HeightData);
+                        }
+                        else
+                        {
+                                UE_LOG(LogPOIService, Warning, TEXT("Fallback ModifyHeightfield failed for stamp operation %s at (%.1f, %.1f)"),
+                                        *UEnum::GetDisplayValueAsText(Operation).ToString(), Location.X, Location.Y);
+                        }
+                }
+        }
+
+        if (bApplied)
+        {
+                const FString NeighborNote = bTouchesNeighborTiles ? TEXT(" (affects neighbor tiles)") : TEXT("");
+                UE_LOG(LogPOIService, Verbose, TEXT("Applied %s terrain stamp at (%.1f, %.1f, %.1f) with radius %.1f (strength %.2f)%s"),
+                        *UEnum::GetDisplayValueAsText(Operation).ToString(), Location.X, Location.Y, Location.Z, EffectiveRadius, Strength, *NeighborNote);
+        }
+
+        return bApplied;
 }
 
 TArray<FPOIData> UPOIService::GetPOIsInArea(FVector Center, float Radius)
@@ -720,14 +780,14 @@ void UPOIService::ApplyFlatteningStamp(FVector2D Center, float Radius, float Str
 
 void UPOIService::ApplyRaiseStamp(FVector2D Center, float Radius, float Strength, float RaiseHeightMeters, TArray<float>& HeightData, FTileCoord TileCoord) const
 {
-	if (RaiseHeightMeters == 0.0f || Strength <= KINDA_SMALL_NUMBER)
-	{
-		return;
-	}
+        if (RaiseHeightMeters == 0.0f || Strength <= KINDA_SMALL_NUMBER)
+        {
+                return;
+        }
 
-	const int32 Resolution = FMath::Sqrt(static_cast<float>(HeightData.Num()));
-	const float TileSize = WorldGenSettings.TileSizeMeters;
-	const float TargetHeight = GetHeightAtTileLocation(Center, HeightData, TileCoord) + RaiseHeightMeters;
+        const int32 Resolution = FMath::Sqrt(static_cast<float>(HeightData.Num()));
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float TargetHeight = GetHeightAtTileLocation(Center, HeightData, TileCoord) + RaiseHeightMeters;
 
 	for (int32 Y = 0; Y < Resolution; ++Y)
 	{
@@ -751,15 +811,51 @@ void UPOIService::ApplyRaiseStamp(FVector2D Center, float Radius, float Strength
 			const float CurrentHeight = HeightData[Index];
 			HeightData[Index] = FMath::Lerp(CurrentHeight, TargetHeight, Strength * Falloff);
 		}
-	}
+        }
+}
+
+void UPOIService::ApplyLowerStamp(FVector2D Center, float Radius, float Strength, float LowerDepthMeters, TArray<float>& HeightData, FTileCoord TileCoord) const
+{
+        if (LowerDepthMeters <= 0.0f || Strength <= KINDA_SMALL_NUMBER)
+        {
+                return;
+        }
+
+        const int32 Resolution = FMath::Sqrt(static_cast<float>(HeightData.Num()));
+        const float TileSize = WorldGenSettings.TileSizeMeters;
+        const float TargetHeight = GetHeightAtTileLocation(Center, HeightData, TileCoord) - LowerDepthMeters;
+
+        for (int32 Y = 0; Y < Resolution; ++Y)
+        {
+                for (int32 X = 0; X < Resolution; ++X)
+                {
+                        FVector2D LocalPos(
+                                (X / float(Resolution - 1) - 0.5f) * TileSize,
+                                (Y / float(Resolution - 1) - 0.5f) * TileSize
+                        );
+
+                        float Distance = FVector2D::Distance(LocalPos, Center);
+                        if (Distance > Radius)
+                        {
+                                continue;
+                        }
+
+                        float Falloff = 1.0f - (Distance / Radius);
+                        Falloff = FMath::SmoothStep(0.0f, 1.0f, Falloff);
+
+                        const int32 Index = Y * Resolution + X;
+                        const float CurrentHeight = HeightData[Index];
+                        HeightData[Index] = FMath::Lerp(CurrentHeight, TargetHeight, Strength * Falloff);
+                }
+        }
 }
 
 void UPOIService::ApplySmoothStamp(FVector2D Center, float Radius, int32 Iterations, TArray<float>& HeightData, FTileCoord TileCoord) const
 {
-	if (Iterations <= 0)
-	{
-		return;
-	}
+        if (Iterations <= 0)
+        {
+                return;
+        }
 
 	const int32 Resolution = FMath::Sqrt(static_cast<float>(HeightData.Num()));
 	const float TileSize = WorldGenSettings.TileSizeMeters;
@@ -838,14 +934,28 @@ void UPOIService::ApplySmoothStamp(FVector2D Center, float Radius, int32 Iterati
 				HeightData[Index] = WorkingHeights[Index];
 			}
 		}
-	}
+        }
+}
+
+void UPOIService::SyncHeightDataFromService(const FTileCoord& TileCoord, TArray<float>& InOutHeightData) const
+{
+        if (!HeightfieldService)
+        {
+                return;
+        }
+
+        FHeightfieldData CachedData;
+        if (HeightfieldService->GetCachedHeightfield(TileCoord, CachedData) && CachedData.HeightData.Num() > 0)
+        {
+                InOutHeightData = CachedData.HeightData;
+        }
 }
 
 // Utility and persistence functions
 FVector2D UPOIService::WorldToTileLocal(FVector WorldPosition, FTileCoord TileCoord) const
 {
-	FVector TileCenter = TileCoord.ToWorldPosition(WorldGenSettings.TileSizeMeters);
-	return FVector2D(WorldPosition.X - TileCenter.X, WorldPosition.Y - TileCenter.Y);
+        FVector TileCenter = TileCoord.ToWorldPosition(WorldGenSettings.TileSizeMeters);
+        return FVector2D(WorldPosition.X - TileCenter.X, WorldPosition.Y - TileCenter.Y);
 }
 
 FVector UPOIService::TileLocalToWorld(FVector2D LocalPosition, FTileCoord TileCoord) const
@@ -1526,12 +1636,15 @@ void UPOIService::ReconcileLoadedPOI(FPOIData& POIData, const TOptional<FPOISpaw
 	case EPOITerrainStampMode::Flatten:
 		HeightfieldService->ModifyHeightfield(POIData.Location, EffectiveRadius, EffectiveStrength, EHeightfieldOperation::Flatten);
 		break;
-	case EPOITerrainStampMode::Raise:
-		HeightfieldService->ModifyHeightfield(POIData.Location, EffectiveRadius, Stamp.RaiseHeightMeters * EffectiveStrength, EHeightfieldOperation::Add);
-		break;
-	case EPOITerrainStampMode::Smooth:
-		HeightfieldService->ModifyHeightfield(POIData.Location, EffectiveRadius, EffectiveStrength, EHeightfieldOperation::Smooth);
-		break;
+        case EPOITerrainStampMode::Raise:
+                HeightfieldService->ModifyHeightfield(POIData.Location, EffectiveRadius, Stamp.RaiseHeightMeters * EffectiveStrength, EHeightfieldOperation::Add);
+                break;
+        case EPOITerrainStampMode::Lower:
+                HeightfieldService->ModifyHeightfield(POIData.Location, EffectiveRadius, Stamp.LowerDepthMeters * EffectiveStrength, EHeightfieldOperation::Subtract);
+                break;
+        case EPOITerrainStampMode::Smooth:
+                HeightfieldService->ModifyHeightfield(POIData.Location, EffectiveRadius, EffectiveStrength, EHeightfieldOperation::Smooth);
+                break;
 	default:
 		break;
 	}

--- a/Source/Vibeheim/WorldGen/Private/Services/TileStreamingService.cpp
+++ b/Source/Vibeheim/WorldGen/Private/Services/TileStreamingService.cpp
@@ -18,6 +18,12 @@
 
 DEFINE_LOG_CATEGORY_STATIC(LogTileStreaming, Log, All);
 
+namespace
+{
+    constexpr double FrameTimeHistorySeconds = 6.0;
+    constexpr float ActivationSpikeThresholdMs = 8.0f;
+}
+
 UTileStreamingService::UTileStreamingService()
 {
 	HeightfieldService = nullptr;
@@ -1324,10 +1330,16 @@ void UTileStreamingService::NotifyVHMRenderer(const TArray<FTileCoord>& ActiveTi
             TileData->GTOverheadMs = FMath::Max(0.0f, CallMs - MeshMs);
 
             // Compute recent thread spike around activation
-            const float SpikeMs = ComputeRecentSpikeMs(After, /*WindowSec=*/3.0);
+            float BaselineMs = 0.0f;
+            const float SpikeMs = ComputeRecentSpikeMs(After, /*WindowSec=*/3.0, &BaselineMs);
             TileData->ThreadSpikesMs = SpikeMs;
+            if (SpikeMs > ActivationSpikeThresholdMs && BaselineMs > KINDA_SMALL_NUMBER)
+            {
+                UE_LOG(LogTileStreaming, Warning, TEXT("Activation spike %.2fms detected for tile (%d,%d) above %.2fms baseline"),
+                    SpikeMs, TileCoord.X, TileCoord.Y, BaselineMs);
+            }
 
-			CurrentBudgets.ConsumeVHM(CallMs);
+                        CurrentBudgets.ConsumeVHM(CallMs);
         }
     }
 
@@ -1348,6 +1360,18 @@ void UTileStreamingService::SampleFrameTime()
     const float FrameMs = FApp::GetDeltaTime() * 1000.0f;
     const double Now = FPlatformTime::Seconds();
     FrameTimeSamples.Emplace(Now, FrameMs);
+
+    const double MinTime = Now - FrameTimeHistorySeconds;
+    int32 RemoveCount = 0;
+    while (RemoveCount < FrameTimeSamples.Num() && FrameTimeSamples[RemoveCount].Key < MinTime)
+    {
+        ++RemoveCount;
+    }
+    if (RemoveCount > 0)
+    {
+        FrameTimeSamples.RemoveAt(0, RemoveCount, EAllowShrinking::No);
+    }
+
     if (FrameTimeSamples.Num() > MaxFrameSamples)
     {
         const int32 Excess = FrameTimeSamples.Num() - MaxFrameSamples;
@@ -1355,10 +1379,14 @@ void UTileStreamingService::SampleFrameTime()
     }
 }
 
-float UTileStreamingService::ComputeRecentSpikeMs(double NowSeconds, double WindowSec) const
+float UTileStreamingService::ComputeRecentSpikeMs(double NowSeconds, double WindowSec, float* OutBaselineMs) const
 {
     if (FrameTimeSamples.Num() == 0)
     {
+        if (OutBaselineMs)
+        {
+            *OutBaselineMs = 0.0f;
+        }
         return 0.0f;
     }
 
@@ -1382,10 +1410,18 @@ float UTileStreamingService::ComputeRecentSpikeMs(double NowSeconds, double Wind
 
     if (CountInWindow == 0)
     {
+        if (OutBaselineMs)
+        {
+            *OutBaselineMs = (CountBefore > 0) ? (SumBefore / CountBefore) : 0.0f;
+        }
         return 0.0f;
     }
 
     const float Baseline = (CountBefore > 0) ? (SumBefore / CountBefore) : MaxInWindow;
+    if (OutBaselineMs)
+    {
+        *OutBaselineMs = Baseline;
+    }
     return FMath::Max(0.0f, MaxInWindow - Baseline);
 }
 
@@ -1400,7 +1436,7 @@ bool UTileStreamingService::ExportPerformanceCSV(const FString& OptionalFileName
     const FString Path = Dir / Filename;
 
     FString Out;
-    Out += TEXT("TileX,TileY,GenMs,PCGMs,StreamInMs,GTOverheadMs,ThreadSpikesMs\n");
+    Out += TEXT("TileX,TileY,GenMs,PCGMs,StreamInMs,GTOverheadMs,ThreadSpikesMs,ErrorCode\n");
 
     // Write rows for cached tiles
     for (const auto& Pair : TileCache)
@@ -1410,26 +1446,25 @@ bool UTileStreamingService::ExportPerformanceCSV(const FString& OptionalFileName
 
         if (!D.ErrorCode.IsEmpty())
         {
-            const FString Err = FString::Printf(TEXT("ERR:%s"), *D.ErrorCode);
-            Out += FString::Printf(TEXT("%d,%d,%s,%s,%s,%s,%s\n"), T.X, T.Y, *Err, *Err, *Err, *Err, *Err);
+            Out += FString::Printf(TEXT("%d,%d,,,,,%s\n"), T.X, T.Y, *D.ErrorCode);
         }
         else
         {
-            Out += FString::Printf(TEXT("%d,%d,%.2f,%.2f,%.2f,%.2f,%.2f\n"),
+            Out += FString::Printf(TEXT("%d,%d,%.2f,%.2f,%.2f,%.2f,%.2f,%s\n"),
                 T.X, T.Y,
                 D.GenerationTimeMs,
                 D.PCGGenerationTimeMs,
                 D.StreamInTimeMs,
                 D.GTOverheadMs,
-                D.ThreadSpikesMs);
+                D.ThreadSpikesMs,
+                TEXT(""));
         }
     }
 
     // Write rows for explicit error entries that may not be cached
     for (const FTileErrorEntry& E : ErrorEntries)
     {
-        const FString Err = FString::Printf(TEXT("ERR:%s"), *E.Code);
-        Out += FString::Printf(TEXT("%d,%d,%s,%s,%s,%s,%s\n"), E.Tile.X, E.Tile.Y, *Err, *Err, *Err, *Err, *Err);
+        Out += FString::Printf(TEXT("%d,%d,,,,,%s\n"), E.Tile.X, E.Tile.Y, *E.Code);
     }
 
     const bool bSaved = FFileHelper::SaveStringToFile(Out, *Path);

--- a/Source/Vibeheim/WorldGen/Public/Data/WorldGenTypes.h
+++ b/Source/Vibeheim/WorldGen/Public/Data/WorldGenTypes.h
@@ -594,10 +594,11 @@ struct VIBEHEIM_API FPCGSpawnParams
 UENUM(BlueprintType)
 enum class EPOITerrainStampMode : uint8
 {
-	None = 0,
-	Flatten,
-	Raise,
-	Smooth
+        None = 0,
+        Flatten,
+        Raise,
+        Lower,
+        Smooth
 };
 
 /**
@@ -620,9 +621,13 @@ struct VIBEHEIM_API FPOITerrainStampSettings
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "POI")
 	float Strength = 1.0f;
 
-	/** Additional height to raise the center (meters) when Operation == Raise. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "POI")
-	float RaiseHeightMeters = 1.0f;
+        /** Additional height to raise the center (meters) when Operation == Raise. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "POI")
+        float RaiseHeightMeters = 1.0f;
+
+        /** Depth to lower the terrain (meters) when Operation == Lower. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "POI")
+        float LowerDepthMeters = 1.0f;
 
 	/** Number of smoothing iterations when Operation == Smooth. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "POI")

--- a/Source/Vibeheim/WorldGen/Public/Services/IPOIService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/IPOIService.h
@@ -28,7 +28,7 @@ public:
 	/**
 	 * Generate POIs for a specific tile using stratified placement
 	 */
-	virtual TArray<FPOIData> GenerateTilePOIs(FTileCoord TileCoord, EBiomeType BiomeType, const TArray<float>& HeightData) = 0;
+        virtual TArray<FPOIData> GenerateTilePOIs(FTileCoord TileCoord, EBiomeType BiomeType, TArray<float>& HeightData) = 0;
 
 	/**
 	 * Validate POI placement location with slope and flat ground checks

--- a/Source/Vibeheim/WorldGen/Public/Services/POIService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/POIService.h
@@ -81,7 +81,7 @@ public:
 
 	// IPOIServiceInterface interface
 	virtual bool Initialize(const FWorldGenConfig& Settings) override;
-	virtual TArray<FPOIData> GenerateTilePOIs(FTileCoord TileCoord, EBiomeType BiomeType, const TArray<float>& HeightData) override;
+        virtual TArray<FPOIData> GenerateTilePOIs(FTileCoord TileCoord, EBiomeType BiomeType, TArray<float>& HeightData) override;
 	virtual bool ValidatePOIPlacement(FVector Location, const FPOISpawnRule& Rule, const TArray<float>& HeightData, FTileCoord TileCoord) override;
 	virtual bool CheckPOIDistanceRequirements(FVector Location, const FPOISpawnRule& Rule, const TArray<FPOIData>& ExistingPOIs) override;
 	virtual bool ApplyTerrainStamp(FVector Location, float Radius, TArray<float>& HeightData, FTileCoord TileCoord, const FPOITerrainStampSettings& StampSettings = FPOITerrainStampSettings()) override;
@@ -232,9 +232,11 @@ private:
 	/**
 	 * Apply terrain flattening stamp to heightfield data
 	 */
-	void ApplyFlatteningStamp(FVector2D Center, float Radius, float Strength, TArray<float>& HeightData, FTileCoord TileCoord) const;
-	void ApplyRaiseStamp(FVector2D Center, float Radius, float Strength, float RaiseHeightMeters, TArray<float>& HeightData, FTileCoord TileCoord) const;
-	void ApplySmoothStamp(FVector2D Center, float Radius, int32 Iterations, TArray<float>& HeightData, FTileCoord TileCoord) const;
+    void ApplyFlatteningStamp(FVector2D Center, float Radius, float Strength, TArray<float>& HeightData, FTileCoord TileCoord) const;
+    void ApplyRaiseStamp(FVector2D Center, float Radius, float Strength, float RaiseHeightMeters, TArray<float>& HeightData, FTileCoord TileCoord) const;
+    void ApplyLowerStamp(FVector2D Center, float Radius, float Strength, float LowerDepthMeters, TArray<float>& HeightData, FTileCoord TileCoord) const;
+    void ApplySmoothStamp(FVector2D Center, float Radius, int32 Iterations, TArray<float>& HeightData, FTileCoord TileCoord) const;
+    void SyncHeightDataFromService(const FTileCoord& TileCoord, TArray<float>& InOutHeightData) const;
 
 	/**
 	 * Update performance statistics

--- a/Source/Vibeheim/WorldGen/Public/Services/TileStreamingService.h
+++ b/Source/Vibeheim/WorldGen/Public/Services/TileStreamingService.h
@@ -559,7 +559,7 @@ private:
     /**
      * Compute spike in last WindowSec seconds relative to baseline
      */
-    float ComputeRecentSpikeMs(double NowSeconds, double WindowSec = 3.0) const;
+    float ComputeRecentSpikeMs(double NowSeconds, double WindowSec = 3.0, float* OutBaselineMs = nullptr) const;
 
 	/**
 	 * Drain queued generation work while respecting streaming budgets


### PR DESCRIPTION
## Summary
- add lower terrain stamp support, reuse HeightfieldService persistence, and wire stamping into POI generation
- expose mutable tile height data in the POI service and sync back to cached heightfields after modifications
- track frame time spikes over a rolling window, log large activation spikes, and export CSV metrics with an explicit error column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5950c2fd8832abab3ef16cdc43ebe