### PR TITLE
Implement resource reservation system for NPC needs

### DIFF
--- a/.kiro/specs/npc-needs-system/tasks.md
+++ b/.kiro/specs/npc-needs-system/tasks.md
@@ -25,7 +25,7 @@
   - Build & fix (fast compile checkpoint)
   - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 2.4, 11.1, 11.2_
 
-- [ ] 4. Resource system (actor-local, no tick)
+- [x] 4. Resource system (actor-local, no tick)
   - IVHMUsableResource UInterface: CanUse, BeginUse, TickUse, EndUse
   - AVHMResourceActor: FGameplayTag ResourceTag, UseRadius, Quantity (<0 infinite), MaxConcurrentUsers
   - Reservations: TryReserve(User), HeartbeatReservation(Id), ReleaseReservation(Id); expire on heartbeat lapse

--- a/Source/Vibeheim/NPC/Private/VHMResourceActor.cpp
+++ b/Source/Vibeheim/NPC/Private/VHMResourceActor.cpp
@@ -1,0 +1,305 @@
+#include "VHMResourceActor.h"
+
+#include "Components/PrimitiveComponent.h"
+#include "Components/SceneComponent.h"
+#include "Engine/World.h"
+#include "GameFramework/Pawn.h"
+#include "VHMNPCTags.h"
+
+namespace
+{
+    constexpr float DEFAULT_USE_RADIUS = 150.0f;
+    constexpr int32 DEFAULT_MAX_CONCURRENT_USERS = 1;
+    constexpr float DEFAULT_HEARTBEAT_TIMEOUT = 2.0f;
+}
+
+AVHMResourceActor::AVHMResourceActor()
+{
+    PrimaryActorTick.bCanEverTick = false;
+    PrimaryActorTick.bStartWithTickEnabled = false;
+
+    SceneRoot = CreateDefaultSubobject<USceneComponent>(TEXT("SceneRoot"));
+    SetRootComponent(SceneRoot);
+
+    ResourceTag = FGameplayTag();
+    UseRadius = DEFAULT_USE_RADIUS;
+    Quantity = -1; // Infinite by default
+    MaxConcurrentUsers = DEFAULT_MAX_CONCURRENT_USERS;
+    ReservationHeartbeatTimeout = DEFAULT_HEARTBEAT_TIMEOUT;
+    bAutoConfigureCollision = true;
+}
+
+bool AVHMResourceActor::CanUse_Implementation(EVHMNeed NeedType, APawn* User) const
+{
+    if (!IsValid(User))
+    {
+        return false;
+    }
+
+    if (ResourceTag.IsValid())
+    {
+        // Default CanUse simply ensures we still have quantity when finite.
+        if (!IsQuantityInfinite() && Quantity <= 0)
+        {
+            return false;
+        }
+    }
+
+    if (!HasOpenReservationSlot())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+FVHMUseHandle AVHMResourceActor::BeginUse_Implementation(APawn* User, EVHMNeed NeedType, const FGuid& ReservationId)
+{
+    FVHMUseHandle Handle;
+
+    if (!IsValid(User))
+    {
+        return Handle;
+    }
+
+    const float CurrentTime = GetWorld() ? GetWorld()->GetTimeSeconds() : 0.0f;
+
+    const FVHMReservationSlot* Reservation = ActiveReservations.Find(ReservationId);
+    if (!Reservation || Reservation->User.Get() != User)
+    {
+        return Handle;
+    }
+
+    Handle.Resource = this;
+    Handle.User = User;
+    Handle.ReservationId = ReservationId;
+    Handle.LastHeartbeatTime = CurrentTime;
+
+    return Handle;
+}
+
+bool AVHMResourceActor::TickUse_Implementation(const FVHMUseHandle& Handle, float DeltaSeconds)
+{
+    if (!Handle.IsValid())
+    {
+        return false;
+    }
+
+    // Default TickUse keeps reservation alive while resource is in use.
+    return HeartbeatReservation(Handle.ReservationId);
+}
+
+void AVHMResourceActor::EndUse_Implementation(const FVHMUseHandle& Handle)
+{
+    if (Handle.ReservationId.IsValid())
+    {
+        ReleaseReservation(Handle.ReservationId);
+    }
+}
+
+FGuid AVHMResourceActor::TryReserve(APawn* User)
+{
+    if (!IsValid(User))
+    {
+        return FGuid();
+    }
+
+    UWorld* World = GetWorld();
+    const float CurrentTime = World ? World->GetTimeSeconds() : 0.0f;
+    ExpireStaleReservations(CurrentTime);
+
+    if (!IsQuantityInfinite() && Quantity <= 0)
+    {
+        return FGuid();
+    }
+
+    for (const TPair<FGuid, FVHMReservationSlot>& Pair : ActiveReservations)
+    {
+        if (Pair.Value.User == User)
+        {
+            return Pair.Key;
+        }
+    }
+
+    if (!HasOpenReservationSlot())
+    {
+        return FGuid();
+    }
+
+    FGuid NewId = FGuid::NewGuid();
+    ensureAlwaysMsgf(NewId.IsValid(), TEXT("ReservationId must be valid"));
+
+    FVHMReservationSlot& Slot = ActiveReservations.Add(NewId);
+    Slot.User = User;
+    Slot.LastHeartbeatTime = CurrentTime;
+
+    return NewId;
+}
+
+bool AVHMResourceActor::HeartbeatReservation(const FGuid& ReservationId)
+{
+    if (!ReservationId.IsValid())
+    {
+        return false;
+    }
+
+    FVHMReservationSlot* Slot = ActiveReservations.Find(ReservationId);
+    if (!Slot)
+    {
+        return false;
+    }
+
+    const float CurrentTime = GetWorld() ? GetWorld()->GetTimeSeconds() : 0.0f;
+    if (CurrentTime - Slot->LastHeartbeatTime > ReservationHeartbeatTimeout)
+    {
+        ActiveReservations.Remove(ReservationId);
+        return false;
+    }
+
+    Slot->LastHeartbeatTime = CurrentTime;
+    return true;
+}
+
+void AVHMResourceActor::ReleaseReservation(const FGuid& ReservationId)
+{
+    if (!ReservationId.IsValid())
+    {
+        return;
+    }
+
+    ActiveReservations.Remove(ReservationId);
+}
+
+void AVHMResourceActor::ReleaseReservationsFor(APawn* User)
+{
+    if (!IsValid(User))
+    {
+        return;
+    }
+
+    TArray<FGuid> ReservationsToRemove;
+    ReservationsToRemove.Reserve(ActiveReservations.Num());
+
+    for (const TPair<FGuid, FVHMReservationSlot>& Pair : ActiveReservations)
+    {
+        if (Pair.Value.User == User)
+        {
+            ReservationsToRemove.Add(Pair.Key);
+        }
+    }
+
+    for (const FGuid& Id : ReservationsToRemove)
+    {
+        ActiveReservations.Remove(Id);
+    }
+}
+
+void AVHMResourceActor::OnUserDestroyed(APawn* User)
+{
+    ReleaseReservationsFor(User);
+}
+
+bool AVHMResourceActor::SpendQuantity(int32 Amount)
+{
+    if (Amount <= 0 || IsQuantityInfinite())
+    {
+        return true;
+    }
+
+    if (Quantity <= 0)
+    {
+        return false;
+    }
+
+    Quantity = FMath::Max(0, Quantity - Amount);
+    if (Quantity == 0)
+    {
+        OnResourceDepleted.Broadcast();
+    }
+
+    return Quantity > 0;
+}
+
+void AVHMResourceActor::PostInitializeComponents()
+{
+    Super::PostInitializeComponents();
+
+    if (!bAutoConfigureCollision)
+    {
+        return;
+    }
+
+    TArray<UPrimitiveComponent*> PrimitiveComponents;
+    GetComponents(PrimitiveComponents);
+
+    for (UPrimitiveComponent* Primitive : PrimitiveComponents)
+    {
+        if (!Primitive)
+        {
+            continue;
+        }
+
+        Primitive->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+        Primitive->SetCollisionObjectType(ECC_GameTraceChannel2);
+        Primitive->SetCollisionResponseToAllChannels(ECR_Ignore);
+        Primitive->SetCollisionResponseToChannel(ECC_GameTraceChannel2, ECR_Block);
+    }
+}
+
+void AVHMResourceActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    ActiveReservations.Empty();
+    Super::EndPlay(EndPlayReason);
+}
+
+bool AVHMResourceActor::HasOpenReservationSlot() const
+{
+    if (IsQuantityInfinite())
+    {
+        return MaxConcurrentUsers <= 0 || ActiveReservations.Num() < MaxConcurrentUsers;
+    }
+
+    const int32 MaxUsers = FMath::Min(MaxConcurrentUsers, Quantity);
+    return ActiveReservations.Num() < MaxUsers;
+}
+
+void AVHMResourceActor::ExpireStaleReservations(float CurrentTime)
+{
+    if (ReservationHeartbeatTimeout <= 0.0f)
+    {
+        return;
+    }
+
+    TArray<FGuid> ExpiredIds;
+    ExpiredIds.Reserve(ActiveReservations.Num());
+
+    for (const TPair<FGuid, FVHMReservationSlot>& Pair : ActiveReservations)
+    {
+        if (CurrentTime - Pair.Value.LastHeartbeatTime > ReservationHeartbeatTimeout)
+        {
+            ExpiredIds.Add(Pair.Key);
+        }
+    }
+
+    for (const FGuid& Id : ExpiredIds)
+    {
+        ActiveReservations.Remove(Id);
+    }
+}
+
+AVHMFoodResourceActor::AVHMFoodResourceActor()
+{
+    ResourceTag = VHMNPCTags::ResourceFood();
+}
+
+AVHMWaterResourceActor::AVHMWaterResourceActor()
+{
+    ResourceTag = VHMNPCTags::ResourceWater();
+    MaxConcurrentUsers = 0; // Unlimited concurrent users for infinite sources
+}
+
+AVHMShelterResourceActor::AVHMShelterResourceActor()
+{
+    ResourceTag = VHMNPCTags::ResourceShelter();
+    MaxConcurrentUsers = 1;
+}

--- a/Source/Vibeheim/NPC/Public/VHMResourceActor.h
+++ b/Source/Vibeheim/NPC/Public/VHMResourceActor.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "GameplayTagContainer.h"
+#include "VHMUsableResource.h"
+#include "VHMResourceActor.generated.h"
+
+class UPrimitiveComponent;
+class USceneComponent;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnResourceDepletedSignature);
+
+USTRUCT()
+struct FVHMReservationSlot
+{
+    GENERATED_BODY()
+
+    UPROPERTY()
+    TWeakObjectPtr<APawn> User;
+
+    UPROPERTY()
+    float LastHeartbeatTime = 0.0f;
+};
+
+UCLASS(Abstract, Blueprintable)
+class VIBEHEIM_API AVHMResourceActor : public AActor, public IVHMUsableResource
+{
+    GENERATED_BODY()
+
+public:
+    AVHMResourceActor();
+
+    // IVHMUsableResource
+    virtual bool CanUse_Implementation(EVHMNeed NeedType, APawn* User) const override;
+    virtual FVHMUseHandle BeginUse_Implementation(APawn* User, EVHMNeed NeedType, const FGuid& ReservationId) override;
+    virtual bool TickUse_Implementation(const FVHMUseHandle& Handle, float DeltaSeconds) override;
+    virtual void EndUse_Implementation(const FVHMUseHandle& Handle) override;
+
+    UFUNCTION(BlueprintCallable, Category = "Resource")
+    FGuid TryReserve(APawn* User);
+
+    UFUNCTION(BlueprintCallable, Category = "Resource")
+    bool HeartbeatReservation(const FGuid& ReservationId);
+
+    UFUNCTION(BlueprintCallable, Category = "Resource")
+    void ReleaseReservation(const FGuid& ReservationId);
+
+    UFUNCTION(BlueprintCallable, Category = "Resource")
+    void ReleaseReservationsFor(APawn* User);
+
+    UFUNCTION(BlueprintCallable, Category = "Resource")
+    void OnUserDestroyed(APawn* User);
+
+    UFUNCTION(BlueprintCallable, Category = "Resource")
+    bool SpendQuantity(int32 Amount = 1);
+
+    UFUNCTION(BlueprintPure, Category = "Resource")
+    bool IsQuantityInfinite() const { return Quantity < 0; }
+
+    UFUNCTION(BlueprintPure, Category = "Resource")
+    int32 GetRemainingQuantity() const { return Quantity; }
+
+    UFUNCTION(BlueprintPure, Category = "Resource")
+    int32 GetActiveReservationCount() const { return ActiveReservations.Num(); }
+
+    UPROPERTY(BlueprintAssignable, Category = "Resource")
+    FOnResourceDepletedSignature OnResourceDepleted;
+
+protected:
+    virtual void PostInitializeComponents() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+    bool HasOpenReservationSlot() const;
+    void ExpireStaleReservations(float CurrentTime);
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Resource")
+    TObjectPtr<USceneComponent> SceneRoot;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Resource")
+    FGameplayTag ResourceTag;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Resource", meta = (ClampMin = "0.0"))
+    float UseRadius;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Resource", meta = (ClampMin = "-1"))
+    int32 Quantity;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Resource", meta = (ClampMin = "0"))
+    int32 MaxConcurrentUsers;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Resource", meta = (ClampMin = "0.1"))
+    float ReservationHeartbeatTimeout;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Resource")
+    bool bAutoConfigureCollision;
+
+    UPROPERTY(VisibleInstanceOnly, Category = "Resource")
+    TMap<FGuid, FVHMReservationSlot> ActiveReservations;
+};
+
+UCLASS()
+class VIBEHEIM_API AVHMFoodResourceActor : public AVHMResourceActor
+{
+    GENERATED_BODY()
+
+public:
+    AVHMFoodResourceActor();
+};
+
+UCLASS()
+class VIBEHEIM_API AVHMWaterResourceActor : public AVHMResourceActor
+{
+    GENERATED_BODY()
+
+public:
+    AVHMWaterResourceActor();
+};
+
+UCLASS()
+class VIBEHEIM_API AVHMShelterResourceActor : public AVHMResourceActor
+{
+    GENERATED_BODY()
+
+public:
+    AVHMShelterResourceActor();
+};

--- a/Source/Vibeheim/NPC/Public/VHMUsableResource.h
+++ b/Source/Vibeheim/NPC/Public/VHMUsableResource.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+#include "VHMNPCTypes.h"
+#include "VHMUsableResource.generated.h"
+
+class APawn;
+
+UINTERFACE(BlueprintType)
+class VIBEHEIM_API UVHMUsableResource : public UInterface
+{
+    GENERATED_BODY()
+};
+
+class VIBEHEIM_API IVHMUsableResource
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "Resource")
+    bool CanUse(EVHMNeed NeedType, APawn* User) const;
+
+    UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "Resource")
+    FVHMUseHandle BeginUse(APawn* User, EVHMNeed NeedType, const FGuid& ReservationId);
+
+    UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "Resource")
+    bool TickUse(const FVHMUseHandle& Handle, float DeltaSeconds);
+
+    UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "Resource")
+    void EndUse(const FVHMUseHandle& Handle);
+};


### PR DESCRIPTION
## Summary
- add a reusable UVHMUsableResource interface so resource actors expose consumption hooks
- implement AVHMResourceActor with reservation, heartbeat, and quantity management plus food/water/shelter variants
- mark Task 4 of the NPC needs system implementation plan as complete

## Testing
- Not run (UE build not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fcddad0688832aa9998c5701747054